### PR TITLE
Handle scoped storage permissions via settings flow

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,9 +2,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-    <uses-permission
-        android:name="android.permission.MANAGE_EXTERNAL_STORAGE"
-        android:maxSdkVersion="29" />
+    <!-- MANAGE_EXTERNAL_STORAGE is requested through a settings flow in MainActivity to comply
+         with scoped storage policies while still allowing the app to browse the user's PDF
+         library. -->
+    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
 
     <application
         android:name="com.novapdf.reader.NovaPdfApp"

--- a/app/src/main/kotlin/com/novapdf/reader/MainActivity.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/MainActivity.kt
@@ -1,28 +1,52 @@
 package com.novapdf.reader
 
 import android.Manifest
+import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
+import android.os.Environment
+import android.provider.Settings
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
+import androidx.annotation.StringRes
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
 import androidx.core.content.ContextCompat
+import androidx.lifecycle.lifecycleScope
+import com.novapdf.reader.R
 import com.novapdf.reader.ui.theme.NovaPdfTheme
+import kotlinx.coroutines.launch
 
 class MainActivity : ComponentActivity() {
     private val viewModel: PdfViewerViewModel by viewModels()
+    private val snackbarHost = SnackbarHostState()
+    private val preferences by lazy { getSharedPreferences(PERMISSION_PREFS, MODE_PRIVATE) }
 
     private val openDocumentLauncher = registerForActivityResult(ActivityResultContracts.GetContent()) { uri: Uri? ->
         uri?.let { viewModel.openDocument(it) }
     }
 
+    private val manageAllFilesPermissionLauncher =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+            handleManageAllFilesResult()
+        }
+
+    private val appSettingsLauncher =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+            requestStoragePermissionIfNeeded()
+        }
+
+    private val readStoragePermissionLauncher =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
+            handleReadStoragePermissionResult(granted)
+        }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val snackbarHost = SnackbarHostState()
         setContent {
             NovaPdfTheme {
                 PdfViewerRoute(
@@ -47,9 +71,115 @@ class MainActivity : ComponentActivity() {
 
     private fun requestStoragePermissionIfNeeded() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) return
-        val permission = Manifest.permission.READ_EXTERNAL_STORAGE
-        if (ContextCompat.checkSelfPermission(this, permission) != PackageManager.PERMISSION_GRANTED) {
-            requestPermissions(arrayOf(permission), 100)
+        val manageStorage = Build.VERSION.SDK_INT >= Build.VERSION_CODES.R
+        val currentlyGranted = if (manageStorage) {
+            Environment.isExternalStorageManager()
+        } else {
+            ContextCompat.checkSelfPermission(
+                this,
+                Manifest.permission.READ_EXTERNAL_STORAGE
+            ) == PackageManager.PERMISSION_GRANTED
         }
+
+        cachePermissionGrantState(currentlyGranted)
+        if (currentlyGranted) return
+
+        if (manageStorage) {
+            val alreadyPrompted = preferences.getBoolean(KEY_MANAGE_PROMPTED, false)
+            if (!alreadyPrompted) {
+                preferences.edit().putBoolean(KEY_MANAGE_PROMPTED, true).apply()
+                showStorageSnackbar(R.string.storage_permission_manage_explanation)
+                launchManageAllFilesSettings()
+            } else {
+                showStorageSnackbar(
+                    messageRes = R.string.storage_permission_denied,
+                    actionRes = R.string.storage_permission_open_settings,
+                    onAction = { launchManageAllFilesSettings() }
+                )
+            }
+        } else {
+            val permission = Manifest.permission.READ_EXTERNAL_STORAGE
+            val alreadyPrompted = preferences.getBoolean(KEY_READ_PROMPTED, false)
+            val shouldRequest = !alreadyPrompted || shouldShowRequestPermissionRationale(permission)
+            if (shouldRequest) {
+                preferences.edit().putBoolean(KEY_READ_PROMPTED, true).apply()
+                showStorageSnackbar(R.string.storage_permission_read_explanation)
+                readStoragePermissionLauncher.launch(permission)
+            } else {
+                showStorageSnackbar(
+                    messageRes = R.string.storage_permission_denied,
+                    actionRes = R.string.storage_permission_open_settings,
+                    onAction = { openAppSettings() }
+                )
+            }
+        }
+    }
+
+    private fun handleManageAllFilesResult() {
+        val granted = Environment.isExternalStorageManager()
+        cachePermissionGrantState(granted)
+        showStorageSnackbar(
+            if (granted) R.string.storage_permission_granted else R.string.storage_permission_denied
+        )
+    }
+
+    private fun handleReadStoragePermissionResult(granted: Boolean) {
+        cachePermissionGrantState(granted)
+        showStorageSnackbar(
+            if (granted) R.string.storage_permission_granted else R.string.storage_permission_denied
+        )
+    }
+
+    private fun launchManageAllFilesSettings() {
+        val packageUri = Uri.fromParts("package", packageName, null)
+        val appIntent = Intent(Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION).apply {
+            data = packageUri
+        }
+        val intent = if (packageManager.resolveActivity(appIntent, PackageManager.MATCH_DEFAULT_ONLY) != null) {
+            appIntent
+        } else {
+            Intent(Settings.ACTION_MANAGE_ALL_FILES_ACCESS_PERMISSION)
+        }
+        manageAllFilesPermissionLauncher.launch(intent)
+    }
+
+    private fun showStorageSnackbar(
+        @StringRes messageRes: Int,
+        @StringRes actionRes: Int? = null,
+        onAction: (() -> Unit)? = null
+    ) {
+        lifecycleScope.launch {
+            val result = snackbarHost.showSnackbar(
+                message = getString(messageRes),
+                actionLabel = actionRes?.let(::getString)
+            )
+            if (result == SnackbarResult.ActionPerformed) {
+                onAction?.invoke()
+            }
+        }
+    }
+
+    private fun cachePermissionGrantState(granted: Boolean) {
+        preferences.edit().apply {
+            putBoolean(KEY_STORAGE_GRANTED, granted)
+            if (granted) {
+                putBoolean(KEY_MANAGE_PROMPTED, false)
+                putBoolean(KEY_READ_PROMPTED, false)
+            }
+        }.apply()
+    }
+
+    private fun openAppSettings() {
+        val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+            data = Uri.fromParts("package", packageName, null)
+        }
+        appSettingsLauncher.launch(intent)
+    }
+
+    companion object {
+        private const val PERMISSION_PREFS = "novapdf_permissions"
+        private const val KEY_STORAGE_GRANTED = "storage_granted"
+        private const val KEY_MANAGE_PROMPTED = "manage_permission_prompted"
+        private const val KEY_READ_PROMPTED = "read_permission_prompted"
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,4 +7,9 @@
     <string name="adaptive_flow_off">Adaptive Flow Paused</string>
     <string name="annotation_saved">Annotations saved</string>
     <string name="annotation_discarded">Annotations discarded</string>
+    <string name="storage_permission_manage_explanation">NovaPDF Reader needs "All files access" to browse and open PDFs stored on your device. Approve the request on the next screen.</string>
+    <string name="storage_permission_read_explanation">NovaPDF Reader needs storage permission to open PDFs stored on your device.</string>
+    <string name="storage_permission_granted">Storage access granted. You can now browse your PDFs.</string>
+    <string name="storage_permission_denied">Storage access is still disabled. You can enable it anytime from Settings.</string>
+    <string name="storage_permission_open_settings">Open settings</string>
 </resources>


### PR DESCRIPTION
## Summary
- request MANAGE_EXTERNAL_STORAGE without a max SDK cap and document the settings gating
- add Manage All Files/READ_EXTERNAL_STORAGE permission launchers with snackbar guidance and cached prompts
- surface actionable permission messaging, including settings shortcuts, to avoid repeated system dialogs

## Testing
- ./gradlew lint *(fails: Android SDK not installed in CI image)*

------
https://chatgpt.com/codex/tasks/task_e_68d339400e7c832bb652c22258abfa84