### PR TITLE
Add Room-backed bookmark storage with migration

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
     id("org.jetbrains.kotlin.plugin.serialization")
+    id("org.jetbrains.kotlin.kapt")
 }
 
 android {
@@ -103,6 +104,10 @@ dependencies {
     implementation("androidx.appcompat:appcompat:1.7.0")
     implementation("androidx.constraintlayout:constraintlayout-compose:1.0.1")
 
+    implementation("androidx.room:room-runtime:2.6.1")
+    implementation("androidx.room:room-ktx:2.6.1")
+    kapt("androidx.room:room-compiler:2.6.1")
+
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1")
 
@@ -112,6 +117,7 @@ dependencies {
     testImplementation("org.robolectric:robolectric:4.12.1")
     testImplementation("junit:junit:4.13.2")
     testImplementation("androidx.test:core:1.5.0")
+    testImplementation("androidx.room:room-testing:2.6.1")
 
     androidTestImplementation("androidx.test.ext:junit:1.2.1")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")

--- a/app/src/main/kotlin/com/novapdf/reader/NovaPdfApp.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/NovaPdfApp.kt
@@ -1,8 +1,11 @@
 package com.novapdf.reader
 
 import android.app.Application
+import android.content.Context
+import androidx.room.Room
 import com.novapdf.reader.data.AnnotationRepository
 import com.novapdf.reader.data.BookmarkManager
+import com.novapdf.reader.data.NovaPdfDatabase
 import com.novapdf.reader.data.PdfDocumentRepository
 
 class NovaPdfApp : Application() {
@@ -14,12 +17,22 @@ class NovaPdfApp : Application() {
         private set
     lateinit var bookmarkManager: BookmarkManager
         private set
+    lateinit var database: NovaPdfDatabase
+        private set
 
     override fun onCreate() {
         super.onCreate()
         annotationRepository = AnnotationRepository(this)
         pdfDocumentRepository = PdfDocumentRepository(this)
         adaptiveFlowManager = AdaptiveFlowManager(this)
-        bookmarkManager = BookmarkManager(this)
+        database = Room.databaseBuilder(
+            applicationContext,
+            NovaPdfDatabase::class.java,
+            NovaPdfDatabase.NAME
+        ).fallbackToDestructiveMigration().build()
+        bookmarkManager = BookmarkManager(
+            database.bookmarkDao(),
+            getSharedPreferences(BookmarkManager.LEGACY_PREFERENCES_NAME, Context.MODE_PRIVATE)
+        )
     }
 }

--- a/app/src/main/kotlin/com/novapdf/reader/data/BookmarkDao.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/data/BookmarkDao.kt
@@ -1,0 +1,28 @@
+package com.novapdf.reader.data
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+
+@Dao
+interface BookmarkDao {
+    @Query(
+        "SELECT * FROM bookmarks WHERE document_id = :documentId ORDER BY page_index ASC"
+    )
+    suspend fun bookmarksForDocument(documentId: String): List<BookmarkEntity>
+
+    @Query(
+        "SELECT EXISTS(SELECT 1 FROM bookmarks WHERE document_id = :documentId AND page_index = :pageIndex)"
+    )
+    suspend fun isBookmarked(documentId: String, pageIndex: Int): Boolean
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(bookmark: BookmarkEntity)
+
+    @Query("DELETE FROM bookmarks WHERE document_id = :documentId AND page_index = :pageIndex")
+    suspend fun remove(documentId: String, pageIndex: Int)
+
+    @Query("SELECT COUNT(*) FROM bookmarks")
+    suspend fun countAll(): Int
+}

--- a/app/src/main/kotlin/com/novapdf/reader/data/BookmarkEntity.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/data/BookmarkEntity.kt
@@ -1,0 +1,14 @@
+package com.novapdf.reader.data
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+
+@Entity(tableName = "bookmarks", primaryKeys = ["document_id", "page_index"])
+data class BookmarkEntity(
+    @ColumnInfo(name = "document_id")
+    val documentId: String,
+    @ColumnInfo(name = "page_index")
+    val pageIndex: Int,
+    @ColumnInfo(name = "timestamp")
+    val timestamp: Long
+)

--- a/app/src/main/kotlin/com/novapdf/reader/data/BookmarkManager.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/data/BookmarkManager.kt
@@ -1,35 +1,105 @@
 package com.novapdf.reader.data
 
-import android.content.Context
 import android.content.SharedPreferences
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 
-class BookmarkManager(context: Context) {
-    private val preferences: SharedPreferences =
-        context.getSharedPreferences("novapdf_bookmarks", Context.MODE_PRIVATE)
+class BookmarkManager(
+    private val bookmarkDao: BookmarkDao,
+    private val legacyPreferences: SharedPreferences? = null,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val timeProvider: () -> Long = { System.currentTimeMillis() }
+) {
+    private val migrationMutex = Mutex()
 
-    suspend fun toggleBookmark(documentId: String, pageIndex: Int): Boolean = withContext(Dispatchers.IO) {
-        val key = key(documentId)
-        val entries = preferences.getStringSet(key, emptySet()).orEmpty().toMutableSet()
-        val value = pageIndex.toString()
-        val isBookmarked = if (entries.contains(value)) {
-            entries.remove(value)
-            false
-        } else {
-            entries.add(value)
-            true
+    @Volatile
+    private var migrationComplete = false
+
+    suspend fun toggleBookmark(documentId: String, pageIndex: Int): Boolean {
+        ensureMigration()
+        return withContext(dispatcher) {
+            val exists = bookmarkDao.isBookmarked(documentId, pageIndex)
+            if (exists) {
+                bookmarkDao.remove(documentId, pageIndex)
+                false
+            } else {
+                bookmarkDao.upsert(
+                    BookmarkEntity(
+                        documentId = documentId,
+                        pageIndex = pageIndex,
+                        timestamp = timeProvider()
+                    )
+                )
+                true
+            }
         }
-        preferences.edit().putStringSet(key, entries).apply()
-        isBookmarked
     }
 
-    suspend fun bookmarks(documentId: String): List<Int> = withContext(Dispatchers.IO) {
-        preferences.getStringSet(key(documentId), emptySet())
-            ?.mapNotNull { it.toIntOrNull() }
-            ?.sorted()
-            .orEmpty()
+    suspend fun bookmarks(documentId: String): List<Int> {
+        ensureMigration()
+        return withContext(dispatcher) {
+            bookmarkDao.bookmarksForDocument(documentId).map { it.pageIndex }
+        }
     }
 
-    private fun key(documentId: String): String = "bookmark_$documentId"
+    private suspend fun ensureMigration() {
+        if (migrationComplete) return
+        migrationMutex.withLock {
+            if (migrationComplete) return
+            migrateLegacyBookmarks()
+            migrationComplete = true
+        }
+    }
+
+    private suspend fun migrateLegacyBookmarks() = withContext(dispatcher) {
+        val preferences = legacyPreferences ?: return@withContext
+        val entries = preferences.all.filterKeys { it.startsWith(LEGACY_KEY_PREFIX) }
+        if (entries.isEmpty()) {
+            clearMigrationFlag(preferences)
+            return@withContext
+        }
+        val keysToRemove = mutableListOf<String>()
+        val hasExistingBookmarks = bookmarkDao.countAll() > 0
+        entries.forEach { (key, value) ->
+            val documentId = key.removePrefix(LEGACY_KEY_PREFIX)
+            val pages = (value as? Set<*>)
+                ?.mapNotNull { (it as? String)?.toIntOrNull() }
+                .orEmpty()
+            if (pages.isEmpty() || hasExistingBookmarks) {
+                keysToRemove += key
+                return@forEach
+            }
+            pages.forEach { pageIndex ->
+                bookmarkDao.upsert(
+                    BookmarkEntity(
+                        documentId = documentId,
+                        pageIndex = pageIndex,
+                        timestamp = timeProvider()
+                    )
+                )
+            }
+            keysToRemove += key
+        }
+        if (keysToRemove.isNotEmpty()) {
+            val editor = preferences.edit()
+            keysToRemove.forEach { editor.remove(it) }
+            editor.apply()
+        }
+    }
+
+    private fun clearMigrationFlag(preferences: SharedPreferences) {
+        val keys = preferences.all.keys.filter { it.startsWith(LEGACY_KEY_PREFIX) }
+        if (keys.isEmpty()) return
+        val editor = preferences.edit()
+        keys.forEach { editor.remove(it) }
+        editor.apply()
+    }
+
+    companion object {
+        const val LEGACY_PREFERENCES_NAME: String = "novapdf_bookmarks"
+        private const val LEGACY_KEY_PREFIX = "bookmark_"
+    }
 }

--- a/app/src/main/kotlin/com/novapdf/reader/data/NovaPdfDatabase.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/data/NovaPdfDatabase.kt
@@ -1,0 +1,17 @@
+package com.novapdf.reader.data
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+
+@Database(
+    entities = [BookmarkEntity::class],
+    version = 1,
+    exportSchema = false
+)
+abstract class NovaPdfDatabase : RoomDatabase() {
+    abstract fun bookmarkDao(): BookmarkDao
+
+    companion object {
+        const val NAME: String = "nova_pdf.db"
+    }
+}

--- a/app/src/test/kotlin/com/novapdf/reader/data/BookmarkManagerTest.kt
+++ b/app/src/test/kotlin/com/novapdf/reader/data/BookmarkManagerTest.kt
@@ -1,0 +1,95 @@
+package com.novapdf.reader.data
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.robolectric.junit5.RobolectricExtension
+
+@ExtendWith(RobolectricExtension::class)
+class BookmarkManagerTest {
+    private lateinit var context: Context
+    private lateinit var database: NovaPdfDatabase
+    private lateinit var dao: BookmarkDao
+    private lateinit var preferences: SharedPreferences
+
+    @BeforeEach
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        database = Room.inMemoryDatabaseBuilder(context, NovaPdfDatabase::class.java)
+            .build()
+        dao = database.bookmarkDao()
+        preferences = context.getSharedPreferences(
+            BookmarkManager.LEGACY_PREFERENCES_NAME,
+            Context.MODE_PRIVATE
+        )
+        preferences.edit().clear().commit()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        database.close()
+        preferences.edit().clear().commit()
+    }
+
+    @Test
+    fun toggleBookmarkAddsAndRemovesEntries() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val manager = BookmarkManager(
+            bookmarkDao = dao,
+            dispatcher = dispatcher
+        )
+
+        assertTrue(manager.toggleBookmark("doc", 1))
+        assertEquals(listOf(1), manager.bookmarks("doc"))
+
+        assertFalse(manager.toggleBookmark("doc", 1))
+        assertTrue(manager.bookmarks("doc").isEmpty())
+    }
+
+    @Test
+    fun migratesLegacyPreferencesIntoDatabase() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        preferences.edit()
+            .putStringSet("bookmark_doc", setOf("1", "3", "invalid"))
+            .apply()
+
+        val manager = BookmarkManager(
+            bookmarkDao = dao,
+            legacyPreferences = preferences,
+            dispatcher = dispatcher,
+            timeProvider = { 42L }
+        )
+
+        assertEquals(listOf(1, 3), manager.bookmarks("doc"))
+        val entityTimestamps = dao.bookmarksForDocument("doc").map { it.timestamp }
+        assertTrue(entityTimestamps.all { it == 42L })
+        assertNull(preferences.getStringSet("bookmark_doc", null))
+    }
+
+    @Test
+    fun clearsLegacyPreferencesWhenDatabaseAlreadyPopulated() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        dao.upsert(BookmarkEntity("doc", 5, 10L))
+        preferences.edit().putStringSet("bookmark_doc", setOf("1", "2")).apply()
+
+        val manager = BookmarkManager(
+            bookmarkDao = dao,
+            legacyPreferences = preferences,
+            dispatcher = dispatcher
+        )
+
+        assertEquals(listOf(5), manager.bookmarks("doc"))
+        assertNull(preferences.getStringSet("bookmark_doc", null))
+    }
+}


### PR DESCRIPTION
## Summary
- introduce a Room database with a BookmarkEntity/Dao and wire it through NovaPdfApp
- replace the SharedPreferences-backed BookmarkManager with the Room implementation, including legacy migration logic
- cover the new database behavior with Robolectric-based tests and pull in Room dependencies

## Testing
- `./gradlew test` *(fails: requires Android SDK in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3521f8a98832b98dbd672dfa7574f