### PR TITLE
Update build and Compose toolchain versions

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -40,7 +40,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.13"
+        kotlinCompilerExtensionVersion = "1.5.14"
     }
 
     kotlinOptions {
@@ -85,7 +85,7 @@ android {
 }
 
 dependencies {
-    val composeBom = platform("androidx.compose:compose-bom:2024.06.00")
+    val composeBom = platform("androidx.compose:compose-bom:2024.07.00")
     implementation("androidx.core:core-ktx:1.13.1")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.4")
     implementation("androidx.lifecycle:lifecycle-runtime-compose:2.8.4")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
-    id("com.android.application") version "8.3.2" apply false
-    id("org.jetbrains.kotlin.android") version "1.9.23" apply false
-    id("org.jetbrains.kotlin.plugin.serialization") version "1.9.23" apply false
+    id("com.android.application") version "8.5.0" apply false
+    id("org.jetbrains.kotlin.android") version "1.9.24" apply false
+    id("org.jetbrains.kotlin.plugin.serialization") version "1.9.24" apply false
 }
 
 tasks.register("clean", Delete::class) {


### PR DESCRIPTION
## Summary
- bump the Android Gradle Plugin to 8.5.0 and align Kotlin Android/serialization plugins with 1.9.24
- update Jetpack Compose tooling to the 1.6.8 release train via compiler extension 1.5.14 and BOM 2024.07.00
- confirm the Gradle wrapper stays on the 8.7 distribution to satisfy the newer toolchain requirements

## Testing
- `./gradlew assembleDebug` *(fails: SSLHandshakeException while downloading Gradle 8.7 distribution)*

------
https://chatgpt.com/codex/tasks/task_e_68d379658f90832ba81552868da73c02