### PR TITLE
Fix Compose BOM dependency resolution

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -85,7 +85,7 @@ android {
 }
 
 dependencies {
-    val composeBom = platform("androidx.compose:compose-bom:2024.07.00")
+    val composeBom = platform("androidx.compose:compose-bom:2024.06.00")
     implementation("androidx.core:core-ktx:1.13.1")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.4")
     implementation("androidx.lifecycle:lifecycle-runtime-compose:2.8.4")


### PR DESCRIPTION
## Summary
- update the Compose BOM dependency to a published version so dependency resolution succeeds during builds

## Testing
- `./gradlew assembleDebug --stacktrace` *(fails: SSL handshake issue while downloading Gradle distribution in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d37eb0d01c832bbefe858979f1642b