### PR TITLE
Gate storage permissions behind settings flow

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,9 +2,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-    <!-- MANAGE_EXTERNAL_STORAGE is requested through a settings flow in MainActivity to comply
-         with scoped storage policies while still allowing the app to browse the user's PDF
-         library. -->
+    <!-- MANAGE_EXTERNAL_STORAGE is declared so API 30+ users can opt in from the explicit
+         settings screen launched by MainActivity. Keeping the permission behind that settings
+         flow lets us honour scoped storage/Play policy requirements while still enabling the
+         in-app PDF library browser. -->
     <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
 
     <application

--- a/app/src/main/kotlin/com/novapdf/reader/MainActivity.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/MainActivity.kt
@@ -88,15 +88,17 @@ class MainActivity : ComponentActivity() {
             val alreadyPrompted = preferences.getBoolean(KEY_MANAGE_PROMPTED, false)
             if (!alreadyPrompted) {
                 preferences.edit().putBoolean(KEY_MANAGE_PROMPTED, true).apply()
-                showStorageSnackbar(R.string.storage_permission_manage_explanation)
-                launchManageAllFilesSettings()
-            } else {
-                showStorageSnackbar(
-                    messageRes = R.string.storage_permission_denied,
-                    actionRes = R.string.storage_permission_open_settings,
-                    onAction = { launchManageAllFilesSettings() }
-                )
             }
+            val messageRes = if (alreadyPrompted) {
+                R.string.storage_permission_denied
+            } else {
+                R.string.storage_permission_manage_explanation
+            }
+            showStorageSnackbar(
+                messageRes = messageRes,
+                actionRes = R.string.storage_permission_open_settings,
+                onAction = { launchManageAllFilesSettings() }
+            )
         } else {
             val permission = Manifest.permission.READ_EXTERNAL_STORAGE
             val alreadyPrompted = preferences.getBoolean(KEY_READ_PROMPTED, false)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,7 +7,7 @@
     <string name="adaptive_flow_off">Adaptive Flow Paused</string>
     <string name="annotation_saved">Annotations saved</string>
     <string name="annotation_discarded">Annotations discarded</string>
-    <string name="storage_permission_manage_explanation">NovaPDF Reader needs "All files access" to browse and open PDFs stored on your device. Approve the request on the next screen.</string>
+    <string name="storage_permission_manage_explanation">NovaPDF Reader needs "All files access" to browse and open PDFs stored on your device. Tap Open settings to allow access.</string>
     <string name="storage_permission_read_explanation">NovaPDF Reader needs storage permission to open PDFs stored on your device.</string>
     <string name="storage_permission_granted">Storage access granted. You can now browse your PDFs.</string>
     <string name="storage_permission_denied">Storage access is still disabled. You can enable it anytime from Settings.</string>


### PR DESCRIPTION
## Summary
- document in the manifest that MANAGE_EXTERNAL_STORAGE is only granted via the settings flow
- gate the manage-all-files permission behind a snackbar action so users intentionally open the settings screen
- refresh the permission guidance copy to match the updated flow

## Testing
- `./gradlew lint` *(fails: SSL handshake while downloading Gradle distribution)*

------
https://chatgpt.com/codex/tasks/task_e_68d37f582a3c832bbaf4496c152486b6