### PR TITLE
Integrate tile cache preloading with adaptive flow

### DIFF
--- a/app/src/main/kotlin/com/novapdf/reader/PdfViewerViewModel.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/PdfViewerViewModel.kt
@@ -13,7 +13,6 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.novapdf.reader.data.AnnotationRepository
 import com.novapdf.reader.data.BookmarkManager
-import com.novapdf.reader.data.PageTileRequest
 import com.novapdf.reader.data.PdfDocumentRepository
 import com.novapdf.reader.model.AnnotationCommand
 import com.novapdf.reader.model.SearchMatch
@@ -88,6 +87,18 @@ class PdfViewerViewModel(
                 )
             }
         }
+        viewModelScope.launch {
+            adaptiveFlowManager.preloadTargets.collect { targets ->
+                val spec = lastTileSpec
+                if (spec != null && targets.isNotEmpty()) {
+                    pdfRepository.preloadTiles(
+                        indices = targets,
+                        tileFractions = spec.tileFractions,
+                        scale = spec.scale
+                    )
+                }
+            }
+        }
     }
 
     fun openDocument(uri: Uri) {
@@ -131,13 +142,7 @@ class PdfViewerViewModel(
     }
 
     suspend fun renderTile(index: Int, rect: Rect, scale: Float): Bitmap? {
-        return pdfRepository.renderTile(
-            PageTileRequest(
-                pageIndex = index,
-                tileRect = rect,
-                scale = scale
-            )
-        )
+        return pdfRepository.renderTile(index, rect, scale)
     }
 
     suspend fun pageSize(index: Int): Size? {

--- a/app/src/main/kotlin/com/novapdf/reader/data/PdfDocumentRepository.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/data/PdfDocumentRepository.kt
@@ -130,6 +130,10 @@ class PdfDocumentRepository(
         }
     }
 
+    suspend fun renderTile(pageIndex: Int, tileRect: Rect, scale: Float): Bitmap? {
+        return renderTile(PageTileRequest(pageIndex, tileRect, scale))
+    }
+
     suspend fun renderTile(request: PageTileRequest): Bitmap? = withContextGuard {
         val session = openSession.value ?: return@withContextGuard null
         val key = cacheKey(request)
@@ -179,7 +183,7 @@ class PdfDocumentRepository(
                     tileFractions.forEach { fraction ->
                         val rect = fraction.toPageRect(pageSize)
                         if (!rect.isEmpty) {
-                            renderTile(PageTileRequest(pageIndex, rect, scale))
+                            renderTile(pageIndex, rect, scale)
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- add a convenience tile rendering API on PdfDocumentRepository and reuse it for tile preloading
- collect AdaptiveFlowManager preload targets in the view model to warm the tile cache automatically
- update the view model tile rendering call sites to use the new repository overload

## Testing
- `./gradlew test` *(fails: Gradle distribution download blocked by SSL handshake in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d382c431ac832b8eb2021ca056d85e