### PR TITLE
Add dynamic color theming and accessibility controls

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -96,6 +96,7 @@ dependencies {
     implementation("androidx.compose.ui:ui-tooling-preview")
     implementation("androidx.compose.foundation:foundation")
     implementation("androidx.compose.material3:material3")
+    implementation("androidx.compose.material3:material3-dynamic-color")
     implementation("com.google.android.material:material:1.12.0")
     implementation("androidx.navigation:navigation-compose:2.8.0")
     implementation("androidx.datastore:datastore-preferences:1.1.1")

--- a/app/src/androidTest/kotlin/com/novapdf/reader/PdfViewerScreenTest.kt
+++ b/app/src/androidTest/kotlin/com/novapdf/reader/PdfViewerScreenTest.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.novapdf.reader.R
 import com.novapdf.reader.model.AnnotationCommand
 import com.novapdf.reader.model.SearchResult
 import com.novapdf.reader.ui.theme.NovaPdfTheme
@@ -33,11 +34,18 @@ class PdfViewerScreenTest {
                     onToggleBookmark = {},
                     renderTile = { _, _, _ -> null },
                     requestPageSize = { null },
-                    onTileSpecChanged = {}
+                    onTileSpecChanged = {},
+                    onToggleDynamicColor = {},
+                    onToggleHighContrast = {},
+                    dynamicColorSupported = true
                 )
             }
         }
 
         composeRule.onNodeWithText("Open a PDF to begin").assertIsDisplayed()
+        val dynamicColorLabel = composeRule.activity.getString(R.string.dynamic_color_label)
+        val highContrastLabel = composeRule.activity.getString(R.string.high_contrast_label)
+        composeRule.onNodeWithText(dynamicColorLabel).assertIsDisplayed()
+        composeRule.onNodeWithText(highContrastLabel).assertIsDisplayed()
     }
 }

--- a/app/src/main/kotlin/com/novapdf/reader/MainActivity.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/MainActivity.kt
@@ -15,7 +15,9 @@ import androidx.activity.viewModels
 import androidx.annotation.StringRes
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
+import androidx.compose.ui.graphics.Color
 import androidx.core.content.ContextCompat
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import com.novapdf.reader.R
 import com.novapdf.reader.ui.theme.NovaPdfTheme
@@ -48,7 +50,13 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
-            NovaPdfTheme {
+            val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+            NovaPdfTheme(
+                useDarkTheme = uiState.isNightMode,
+                dynamicColor = uiState.dynamicColorEnabled,
+                highContrast = uiState.highContrastEnabled,
+                seedColor = Color(uiState.themeSeedColor)
+            ) {
                 PdfViewerRoute(
                     viewModel = viewModel,
                     snackbarHost = snackbarHost,

--- a/app/src/main/kotlin/com/novapdf/reader/ui/theme/Theme.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/ui/theme/Theme.kt
@@ -5,13 +5,17 @@ import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
-import androidx.compose.material3.dynamicDarkColorScheme
-import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import com.google.android.material.color.utilities.DynamicColor
+import com.google.android.material.color.utilities.DynamicScheme
+import com.google.android.material.color.utilities.Hct
+import com.google.android.material.color.utilities.MaterialDynamicColors
+import com.google.android.material.color.utilities.SchemeTonalSpot
 
-private val LightColors = lightColorScheme(
+private val FallbackLightColorScheme = lightColorScheme(
     primary = PrimaryRed,
     onPrimary = ColorPalette.White,
     secondary = SecondaryBlue,
@@ -23,7 +27,7 @@ private val LightColors = lightColorScheme(
     tertiary = SecondaryTeal
 )
 
-private val DarkColors = darkColorScheme(
+private val FallbackDarkColorScheme = darkColorScheme(
     primary = PrimaryDark,
     onPrimary = ColorPalette.White,
     secondary = SecondaryTeal,
@@ -39,16 +43,22 @@ private val DarkColors = darkColorScheme(
 fun NovaPdfTheme(
     useDarkTheme: Boolean = isSystemInDarkTheme(),
     dynamicColor: Boolean = true,
+    highContrast: Boolean = false,
+    seedColor: Color = PrimaryRed,
     content: @Composable () -> Unit
 ) {
     val colorScheme: ColorScheme = when {
         dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
-            val context = LocalContext.current
-            if (useDarkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+            val contrastLevel = if (highContrast) HIGH_CONTRAST_LEVEL else DEFAULT_CONTRAST_LEVEL
+            materialColorSchemeFromSeed(
+                seedColor = seedColor,
+                darkTheme = useDarkTheme,
+                contrastLevel = contrastLevel
+            )
         }
 
-        useDarkTheme -> DarkColors
-        else -> LightColors
+        useDarkTheme -> FallbackDarkColorScheme
+        else -> FallbackLightColorScheme
     }
 
     MaterialTheme(
@@ -57,3 +67,54 @@ fun NovaPdfTheme(
         content = content
     )
 }
+
+internal fun materialColorSchemeFromSeed(
+    seedColor: Color,
+    darkTheme: Boolean,
+    contrastLevel: Double
+): ColorScheme {
+    val dynamicColors = MaterialDynamicColors()
+    val scheme = SchemeTonalSpot(
+        Hct.fromInt(seedColor.toArgb()),
+        darkTheme,
+        contrastLevel
+    )
+    return ColorScheme(
+        primary = dynamicColors.primary().toComposeColor(scheme),
+        onPrimary = dynamicColors.onPrimary().toComposeColor(scheme),
+        primaryContainer = dynamicColors.primaryContainer().toComposeColor(scheme),
+        onPrimaryContainer = dynamicColors.onPrimaryContainer().toComposeColor(scheme),
+        inversePrimary = dynamicColors.inversePrimary().toComposeColor(scheme),
+        secondary = dynamicColors.secondary().toComposeColor(scheme),
+        onSecondary = dynamicColors.onSecondary().toComposeColor(scheme),
+        secondaryContainer = dynamicColors.secondaryContainer().toComposeColor(scheme),
+        onSecondaryContainer = dynamicColors.onSecondaryContainer().toComposeColor(scheme),
+        tertiary = dynamicColors.tertiary().toComposeColor(scheme),
+        onTertiary = dynamicColors.onTertiary().toComposeColor(scheme),
+        tertiaryContainer = dynamicColors.tertiaryContainer().toComposeColor(scheme),
+        onTertiaryContainer = dynamicColors.onTertiaryContainer().toComposeColor(scheme),
+        background = dynamicColors.background().toComposeColor(scheme),
+        onBackground = dynamicColors.onBackground().toComposeColor(scheme),
+        surface = dynamicColors.surface().toComposeColor(scheme),
+        onSurface = dynamicColors.onSurface().toComposeColor(scheme),
+        surfaceVariant = dynamicColors.surfaceVariant().toComposeColor(scheme),
+        onSurfaceVariant = dynamicColors.onSurfaceVariant().toComposeColor(scheme),
+        surfaceTint = dynamicColors.surfaceTint().toComposeColor(scheme),
+        inverseSurface = dynamicColors.inverseSurface().toComposeColor(scheme),
+        inverseOnSurface = dynamicColors.inverseOnSurface().toComposeColor(scheme),
+        error = dynamicColors.error().toComposeColor(scheme),
+        onError = dynamicColors.onError().toComposeColor(scheme),
+        errorContainer = dynamicColors.errorContainer().toComposeColor(scheme),
+        onErrorContainer = dynamicColors.onErrorContainer().toComposeColor(scheme),
+        outline = dynamicColors.outline().toComposeColor(scheme),
+        outlineVariant = dynamicColors.outlineVariant().toComposeColor(scheme),
+        scrim = dynamicColors.scrim().toComposeColor(scheme)
+    )
+}
+
+private fun DynamicColor.toComposeColor(scheme: DynamicScheme): Color {
+    return Color(getArgb(scheme).toLong() and 0xFFFFFFFFL)
+}
+
+private const val DEFAULT_CONTRAST_LEVEL = 0.0
+private const val HIGH_CONTRAST_LEVEL = 0.7

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,4 +12,10 @@
     <string name="storage_permission_granted">Storage access granted. You can now browse your PDFs.</string>
     <string name="storage_permission_denied">Storage access is still disabled. You can enable it anytime from Settings.</string>
     <string name="storage_permission_open_settings">Open settings</string>
+    <string name="accessibility_settings_title">Accessibility options</string>
+    <string name="dynamic_color_label">Dynamic colors</string>
+    <string name="dynamic_color_description">Adapt NovaPDF Reader to your document’s palette.</string>
+    <string name="dynamic_color_unsupported">Dynamic colors require Android 12 or newer.</string>
+    <string name="high_contrast_label">High contrast</string>
+    <string name="high_contrast_description">Increase contrast for improved readability.</string>
 </resources>

--- a/app/src/test/kotlin/com/novapdf/reader/ui/theme/DynamicColorSchemeTest.kt
+++ b/app/src/test/kotlin/com/novapdf/reader/ui/theme/DynamicColorSchemeTest.kt
@@ -1,0 +1,52 @@
+package com.novapdf.reader.ui.theme
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import androidx.core.graphics.ColorUtils
+import kotlin.test.assertTrue
+import org.junit.Test
+
+class DynamicColorSchemeTest {
+
+    @Test
+    fun primaryContrastMeetsGuidelines() {
+        val seedColor = Color(0xFF6750A4)
+        val colorScheme = materialColorSchemeFromSeed(
+            seedColor = seedColor,
+            darkTheme = false,
+            contrastLevel = 0.0
+        )
+        assertContrastAtLeast(colorScheme.primary, colorScheme.onPrimary, 4.5)
+        assertContrastAtLeast(colorScheme.surface, colorScheme.onSurface, 4.5)
+    }
+
+    @Test
+    fun highContrastElevatesContrast() {
+        val seedColor = Color(0xFF6750A4)
+        val defaultScheme = materialColorSchemeFromSeed(
+            seedColor = seedColor,
+            darkTheme = false,
+            contrastLevel = 0.0
+        )
+        val highContrastScheme = materialColorSchemeFromSeed(
+            seedColor = seedColor,
+            darkTheme = false,
+            contrastLevel = 0.7
+        )
+        val defaultContrast = ColorUtils.calculateContrast(
+            defaultScheme.onPrimary.toArgb(),
+            defaultScheme.primary.toArgb()
+        )
+        val highContrast = ColorUtils.calculateContrast(
+            highContrastScheme.onPrimary.toArgb(),
+            highContrastScheme.primary.toArgb()
+        )
+        assertTrue(highContrast >= defaultContrast)
+        assertTrue(highContrast >= 7.0)
+    }
+
+    private fun assertContrastAtLeast(background: Color, foreground: Color, minimumRatio: Double) {
+        val contrast = ColorUtils.calculateContrast(foreground.toArgb(), background.toArgb())
+        assertTrue(contrast >= minimumRatio)
+    }
+}


### PR DESCRIPTION
## Summary
- replace NovaPdfTheme's static palettes with Material Color Utilities to generate schemes from a seed color and contrast setting
- expose theme controls in PdfViewerScreen and state so users can toggle dynamic color and high contrast accessibility options
- add instrumentation and unit tests plus string resources to validate the new accessibility UI and color contrast behavior

## Testing
- `./gradlew test` *(fails: gradle wrapper download blocked by SSL handshake in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68d390656e70832bb165d7afdd8bbaf3