### PR TITLE
Download sample PDF from S3 during instrumentation tests

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,4 +9,5 @@
 
 # Binary files should be left untouched
 *.jar           binary
+*.pdf           binary
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,26 @@
 # NovaPDF Reader
 
-NovaPDF Reader is a Jetpack Compose Android application that experiments with "Adaptive Flow Reading" for fluid PDF consumption, annotation, and accessibility enhancements on modern Android devices.
+NovaPDF Reader is a Jetpack Compose Android application that experiments with "Adaptive Flow Reading" for fluid PDF consumption,
+annotation, and accessibility enhancements on modern Android devices.
+
+## Sample PDF fixture
+
+Automated tests and screenshot generation expect a tiny CC0 1.0 licensed document that lives outside of the repository on S3.
+By default the project points at `https://novapdf-sample-assets.s3.us-west-2.amazonaws.com/sample.pdf`, a CC0 1.0 document sized
+specifically for automated smoke tests. If you need to swap in a different document, provide the HTTPS location of that object
+through the Gradle property `-PnovapdfSamplePdfUrl=` when invoking instrumentation workflows (for example,
+`./gradlew connectedCheck -PnovapdfSamplePdfUrl=https://your-bucket.s3.amazonaws.com/sample.pdf`). The instrumentation runner
+receives the same URL through its arguments, downloads the file into the test cache, and renders it to validate the viewer
+pipeline without shipping binary fixtures in source control.
+
+See `docs/sample-pdf-license.md` for the redistribution notice covering the hosted document.
 
 ## Gradle wrapper bootstrap
 
-Binary assets such as the `gradle-wrapper.jar` are intentionally not stored in this repository. Instead, the wrapper JAR is stored as a Base64 text file at `gradle/wrapper/gradle-wrapper.jar.base64`. The included `gradlew` and `gradlew.bat` scripts automatically decode this archive to `gradle/wrapper/gradle-wrapper.jar` (Gradle 8.5) the first time you run them.
+Binary assets such as the `gradle-wrapper.jar` are intentionally not stored in this repository. Instead, the wrapper JAR is stored
+as a Base64 text file at `gradle/wrapper/gradle-wrapper.jar.base64`. The included `gradlew` and `gradlew.bat` scripts automatically
+decode this archive to `gradle/wrapper/gradle-wrapper.jar` (Gradle 8.5) the first time you run them.
 
-If your environment blocks execution of Python, PowerShell, or the `base64` utility, manually decode the file or download the wrapper from `https://services.gradle.org/distributions/gradle-8.5-bin.zip` and copy `gradle-8.5/lib/plugins/gradle-wrapper-8.5.jar` to `gradle/wrapper/gradle-wrapper.jar` before invoking Gradle.
+If your environment blocks execution of Python, PowerShell, or the `base64` utility, manually decode the file or download the wrapper
+from `https://services.gradle.org/distributions/gradle-8.5-bin.zip` and copy `gradle-8.5/lib/plugins/gradle-wrapper-8.5.jar`
+to `gradle/wrapper/gradle-wrapper.jar` before invoking Gradle.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,6 +6,10 @@ plugins {
     id("org.jetbrains.kotlin.kapt")
 }
 
+val defaultSamplePdfUrl = providers
+    .gradleProperty("novapdfSamplePdfUrl")
+    .orElse("https://novapdf-sample-assets.s3.us-west-2.amazonaws.com/sample.pdf")
+
 android {
     namespace = "com.novapdf.reader"
     compileSdk = 35
@@ -19,6 +23,12 @@ android {
 
         vectorDrawables.useSupportLibrary = true
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+
+        val samplePdfUrl = defaultSamplePdfUrl.get()
+        buildConfigField("String", "SAMPLE_PDF_URL", "\"$samplePdfUrl\"")
+        if (samplePdfUrl.isNotBlank()) {
+            testInstrumentationRunnerArguments["samplePdfUrl"] = samplePdfUrl
+        }
     }
 
     buildTypes {

--- a/app/src/androidTest/kotlin/com/novapdf/reader/SampleDocument.kt
+++ b/app/src/androidTest/kotlin/com/novapdf/reader/SampleDocument.kt
@@ -1,0 +1,114 @@
+package com.novapdf.reader
+
+import android.content.Context
+import androidx.core.net.toUri
+import androidx.test.platform.app.InstrumentationRegistry
+import com.novapdf.reader.BuildConfig
+import java.io.File
+import java.io.IOException
+import java.net.HttpURLConnection
+import java.net.URL
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+internal object SampleDocument {
+    private const val CACHE_FILE_NAME = "sample.pdf"
+    private const val ARG_SAMPLE_URL = "samplePdfUrl"
+    private const val SYSTEM_PROPERTY_SAMPLE_URL = "novapdf.samplePdfUrl"
+
+    suspend fun installIntoCache(context: Context): android.net.Uri = withContext(Dispatchers.IO) {
+        val sampleUrl = resolveSampleUrl()
+            ?: throw IllegalStateException(
+                "No sample PDF URL configured. Provide the instrumentation argument \"$ARG_SAMPLE_URL\" or Gradle property \"novapdfSamplePdfUrl\" pointing to an S3 object."
+            )
+
+        val appContext = context.applicationContext
+        val cacheFile = File(appContext.cacheDir, CACHE_FILE_NAME)
+        cacheFile.parentFile?.mkdirs()
+
+        if (!cacheFile.exists() || cacheFile.length() == 0L) {
+            downloadToFile(sampleUrl, cacheFile)
+        }
+
+        cacheFile.toUri()
+    }
+
+    private fun resolveSampleUrl(): String? {
+        val instrumentationArgs = InstrumentationRegistry.getArguments()
+        val fromArgs = instrumentationArgs.getString(ARG_SAMPLE_URL)?.takeIf { it.isNotBlank() }
+        if (fromArgs != null) {
+            return fromArgs
+        }
+
+        val fromEnv = System.getenv("NOVAPDF_SAMPLE_PDF_URL")?.takeIf { it.isNotBlank() }
+        if (fromEnv != null) {
+            return fromEnv
+        }
+
+        val fromSystemProperty = System.getProperty(SYSTEM_PROPERTY_SAMPLE_URL)?.takeIf { it.isNotBlank() }
+        if (fromSystemProperty != null) {
+            return fromSystemProperty
+        }
+
+        return BuildConfig.SAMPLE_PDF_URL.takeIf { it.isNotBlank() }
+    }
+
+    private fun downloadToFile(sourceUrl: String, destination: File) {
+        val parentDir = destination.parentFile ?: throw IOException("Missing cache directory for sample PDF")
+        if (!parentDir.exists()) {
+            parentDir.mkdirs()
+        }
+
+        val connection = (URL(sourceUrl).openConnection() as HttpURLConnection).apply {
+            connectTimeout = 10_000
+            readTimeout = 15_000
+            instanceFollowRedirects = true
+        }
+
+        try {
+            val responseCode = connection.responseCode
+            if (responseCode != HttpURLConnection.HTTP_OK) {
+                val message = buildString {
+                    append("Failed to download sample PDF from ")
+                    append(sourceUrl)
+                    append(". HTTP ")
+                    append(responseCode)
+                    connection.responseMessage?.takeIf { it.isNotBlank() }?.let { reason ->
+                        append(" (")
+                        append(reason)
+                        append(')')
+                    }
+                }
+                throw IOException(message)
+            }
+
+            val tempFile = File(parentDir, destination.name + ".download")
+            if (tempFile.exists() && !tempFile.delete()) {
+                throw IOException("Unable to clear stale temporary download file")
+            }
+
+            connection.inputStream.use { input ->
+                tempFile.outputStream().use { output ->
+                    input.copyTo(output)
+                }
+            }
+
+            if (tempFile.length() == 0L) {
+                tempFile.delete()
+                throw IOException("Downloaded sample PDF is empty")
+            }
+
+            if (destination.exists() && !destination.delete()) {
+                tempFile.delete()
+                throw IOException("Unable to replace cached sample PDF")
+            }
+
+            if (!tempFile.renameTo(destination)) {
+                tempFile.delete()
+                throw IOException("Unable to move downloaded sample PDF into cache")
+            }
+        } finally {
+            connection.disconnect()
+        }
+    }
+}

--- a/app/src/androidTest/kotlin/com/novapdf/reader/SamplePdfInstrumentedTest.kt
+++ b/app/src/androidTest/kotlin/com/novapdf/reader/SamplePdfInstrumentedTest.kt
@@ -1,0 +1,51 @@
+package com.novapdf.reader
+
+import android.graphics.Bitmap
+import android.graphics.Rect
+import android.util.Log
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.novapdf.reader.data.PdfDocumentRepository
+import java.io.File
+import java.io.FileOutputStream
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SamplePdfInstrumentedTest {
+
+    @Test
+    fun openSampleDocumentAndCaptureScreenshot() = runBlocking {
+        val context = ApplicationProvider.getApplicationContext<NovaPdfApp>()
+        val repository = PdfDocumentRepository(context)
+        try {
+            val sampleUri = SampleDocument.installIntoCache(context)
+            val session = repository.open(sampleUri)
+            assertNotNull("Sample PDF should open successfully", session)
+            val nonNullSession = requireNotNull(session)
+            assertEquals(1, nonNullSession.pageCount)
+
+            val pageSize = repository.getPageSize(0)
+            assertNotNull("Sample PDF should report a page size", pageSize)
+            val fullPageSize = requireNotNull(pageSize)
+
+            val fullPage = Rect(0, 0, fullPageSize.width, fullPageSize.height)
+            val bitmap = repository.renderTile(0, fullPage, scale = 1f)
+            assertNotNull("Sample PDF should render a bitmap", bitmap)
+            val renderedPage = requireNotNull(bitmap)
+
+            val screenshotDir = File(context.cacheDir, "instrumentation-screenshots").apply { mkdirs() }
+            val screenshotFile = File(screenshotDir, "sample_page.png")
+            FileOutputStream(screenshotFile).use { stream ->
+                renderedPage.compress(Bitmap.CompressFormat.PNG, 100, stream)
+            }
+            renderedPage.recycle()
+            Log.d("SamplePdfInstrumentedTest", "Saved sample screenshot to ${screenshotFile.absolutePath}")
+        } finally {
+            repository.dispose()
+        }
+    }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <!-- MANAGE_EXTERNAL_STORAGE is declared so API 30+ users can opt in from the explicit
          settings screen launched by MainActivity. Keeping the permission behind that settings

--- a/app/src/main/assets/README.md
+++ b/app/src/main/assets/README.md
@@ -1,4 +1,6 @@
 # Assets Directory
 
-The NovaPDF Reader sample build intentionally ships without a binary PDF asset so that the repository remains fully text-based.
-Place any PDFs required for local testing in this directory at development time; they should not be committed.
+This directory intentionally does not store binary fixtures. Instrumentation tests fetch the CC0 1.0 sample PDF from S3 at
+runtime (see the repository README for configuration details) and place it in the device cache instead.
+
+Feel free to drop additional local test documents here while iterating, but do not commit them to the repository.

--- a/docs/sample-pdf-license.md
+++ b/docs/sample-pdf-license.md
@@ -1,0 +1,5 @@
+# Sample PDF License
+
+The sample PDF hosted at `https://novapdf-sample-assets.s3.us-west-2.amazonaws.com/sample.pdf` is dedicated to the public domain
+under [Creative Commons CC0 1.0](https://creativecommons.org/publicdomain/zero/1.0/). The document is purpose-built for automated
+workflows and may be redistributed without restriction.


### PR DESCRIPTION
## Summary
- document the external S3-hosted sample PDF fixture and its license instead of committing a binary asset
- inject the sample URL into BuildConfig/instrumentation runner arguments and download it into cache during tests
- grant INTERNET permission so instrumentation can retrieve the fixture at runtime

## Testing
- `./gradlew testDebugUnitTest` *(fails: SSL handshake when downloading Gradle distribution)*

------
https://chatgpt.com/codex/tasks/task_e_68d3933067b4832bbe8bc0ebffb3c781