### PR TITLE
Fix indentation in CI keystore decoding step

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -117,15 +117,7 @@ jobs:
         run: |
           set -euo pipefail
           echo "Decoding Android signing keystore to $KEYSTORE_PATH"
-          python3 - <<'PY'
-import base64
-import os
-
-encoded = os.environ["ANDROID_KEYSTORE_BASE64"].strip().encode()
-path = os.environ["KEYSTORE_PATH"]
-with open(path, "wb") as target:
-    target.write(base64.b64decode(encoded))
-PY
+          python3 -c "import base64, os; encoded = os.environ['ANDROID_KEYSTORE_BASE64'].strip().encode(); path = os.environ['KEYSTORE_PATH']; open(path, 'wb').write(base64.b64decode(encoded))"
           chmod 600 "$KEYSTORE_PATH"
       - name: Download Android SDK components
         env:


### PR DESCRIPTION
## Summary
- fix the indentation of the embedded Python script in the CI workflow so the YAML parses correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d3a5ab6410832b8c65d534c104a63d