### PR TITLE
Add frame-aware Adaptive Flow timing and performance tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,20 @@
 NovaPDF Reader is a Jetpack Compose Android application that experiments with "Adaptive Flow Reading" for fluid PDF consumption,
 annotation, and accessibility enhancements on modern Android devices.
 
+## Adaptive Flow performance tooling
+
+Adaptive Flow now records frame pacing through `Choreographer` on the main thread so that preloading logic can back off when the
+UI is under pressure. Two dedicated Gradle tasks are available to exercise the timing heuristics and frame monitoring in
+isolation:
+
+```
+./gradlew adaptiveFlowPerformance
+./gradlew frameMonitoringPerformance
+```
+
+Both tasks reuse the Robolectric unit tests backing the Adaptive Flow manager and give fast feedback without running the full
+unit test suite.
+
 ## Sample PDF fixture
 
 Automated tests and screenshot generation expect a tiny CC0 1.0 licensed document that lives outside of the repository on S3.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,4 +1,6 @@
 
+import org.gradle.api.tasks.testing.Test
+
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
@@ -140,4 +142,29 @@ dependencies {
 
 kotlin {
     jvmToolchain(17)
+}
+
+val debugUnitTest = tasks.named<Test>("testDebugUnitTest")
+
+tasks.register<Test>("adaptiveFlowPerformance") {
+    group = "performance"
+    description = "Runs Adaptive Flow timing regression checks."
+    testClassesDirs = debugUnitTest.get().testClassesDirs
+    classpath = debugUnitTest.get().classpath
+    useJUnitPlatform()
+    filter {
+        includeTestsMatching("com.novapdf.reader.AdaptiveFlowManagerTest.readingSpeedRespondsToPageChanges")
+    }
+}
+
+tasks.register<Test>("frameMonitoringPerformance") {
+    group = "performance"
+    description = "Executes frame monitoring diagnostics for Adaptive Flow."
+    testClassesDirs = debugUnitTest.get().testClassesDirs
+    classpath = debugUnitTest.get().classpath
+    useJUnitPlatform()
+    filter {
+        includeTestsMatching("com.novapdf.reader.AdaptiveFlowManagerTest.frameMetricsReactToJank")
+    }
+    shouldRunAfter("adaptiveFlowPerformance")
 }

--- a/app/src/main/kotlin/com/novapdf/reader/AdaptiveFlowManager.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/AdaptiveFlowManager.kt
@@ -5,23 +5,31 @@ import android.hardware.Sensor
 import android.hardware.SensorEvent
 import android.hardware.SensorEventListener
 import android.hardware.SensorManager
-import android.os.SystemClock
+import android.view.Choreographer
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import kotlin.math.max
 import kotlin.math.abs
 import kotlin.math.sqrt
 
 private const val MAX_TRACKED_PAGES = 8
 private const val MAX_ACCELERATION = 12f
+private const val MAX_TRACKED_FRAMES = 90
+private const val DEFAULT_FRAME_INTERVAL_MS = 16.6f
 
-class AdaptiveFlowManager(context: Context) : SensorEventListener {
+class AdaptiveFlowManager(
+    context: Context,
+    private val wallClock: () -> Long = System::currentTimeMillis,
+    private val coroutineScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+) : SensorEventListener {
     private val sensorManager = context.getSystemService(Context.SENSOR_SERVICE) as SensorManager
     private val accelerometer: Sensor? = sensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER)
-    private val coroutineScope = CoroutineScope(Dispatchers.Default)
+    private var choreographer: Choreographer? = null
 
     private val pageHistory = ArrayDeque<Pair<Int, Long>>()
     private val _swipeSensitivity = MutableStateFlow(1f)
@@ -33,8 +41,24 @@ class AdaptiveFlowManager(context: Context) : SensorEventListener {
     private val _readingSpeedPagesPerMinute = MutableStateFlow(30f)
     val readingSpeedPagesPerMinute: StateFlow<Float> = _readingSpeedPagesPerMinute.asStateFlow()
 
+    private val _frameIntervalMillis = MutableStateFlow(DEFAULT_FRAME_INTERVAL_MS)
+    val frameIntervalMillis: StateFlow<Float> = _frameIntervalMillis.asStateFlow()
+
     private var lastTiltMagnitude = 0f
     private var isRegistered = false
+    private var isFrameCallbackRegistered = false
+    private var lastFrameTimeNanos = 0L
+    private val frameDurations = ArrayDeque<Float>()
+
+    private val frameCallback = Choreographer.FrameCallback { frameTimeNanos ->
+        val currentChoreographer = choreographer ?: return@FrameCallback
+        if (lastFrameTimeNanos != 0L) {
+            val deltaMillis = (frameTimeNanos - lastFrameTimeNanos) / 1_000_000f
+            updateFrameMetrics(deltaMillis)
+        }
+        lastFrameTimeNanos = frameTimeNanos
+        currentChoreographer.postFrameCallback(frameCallback)
+    }
 
     fun start() {
         if (!isRegistered) {
@@ -43,6 +67,7 @@ class AdaptiveFlowManager(context: Context) : SensorEventListener {
                 isRegistered = true
             }
         }
+        startFrameMonitoring()
     }
 
     fun stop() {
@@ -50,10 +75,11 @@ class AdaptiveFlowManager(context: Context) : SensorEventListener {
             sensorManager.unregisterListener(this)
             isRegistered = false
         }
+        stopFrameMonitoring()
     }
 
     fun trackPageChange(pageIndex: Int, totalPages: Int) {
-        val now = SystemClock.elapsedRealtime()
+        val now = wallClock()
         pageHistory.addLast(pageIndex to now)
         while (pageHistory.size > MAX_TRACKED_PAGES) {
             pageHistory.removeFirst()
@@ -74,16 +100,28 @@ class AdaptiveFlowManager(context: Context) : SensorEventListener {
     private fun updatePreloadTargets(currentPage: Int, totalPages: Int) {
         coroutineScope.launch {
             val speed = readingSpeedPagesPerMinute.value
+            val frameInterval = frameIntervalMillis.value
             val predictedAdvance = (speed / 60f).coerceAtLeast(0.5f)
             val additionalPages = when {
                 predictedAdvance > 3f -> 4
                 predictedAdvance > 1.5f -> 3
                 else -> 2
             }
+            val frameAdjustment = when {
+                frameInterval > 28f -> -2
+                frameInterval > 22f -> -1
+                frameInterval < 14f -> 1
+                else -> 0
+            }
             val tiltBoost = if (lastTiltMagnitude > 1.4f) 1 else 0
-            val pagesToPreload = (1..(additionalPages + tiltBoost)).mapNotNull { delta ->
-                val index = currentPage + delta
-                index.takeIf { it < totalPages }
+            val targetCount = max(0, additionalPages + tiltBoost + frameAdjustment)
+            val pagesToPreload = if (targetCount == 0) {
+                emptyList()
+            } else {
+                (1..targetCount).mapNotNull { delta ->
+                    val index = currentPage + delta
+                    index.takeIf { it < totalPages }
+                }
             }
             _preloadTargets.value = pagesToPreload
         }
@@ -97,8 +135,52 @@ class AdaptiveFlowManager(context: Context) : SensorEventListener {
         val magnitude = sqrt(x * x + y * y + z * z)
         lastTiltMagnitude = magnitude / SensorManager.GRAVITY_EARTH
         val sensitivity = 1f + (abs(y) + abs(x)) / MAX_ACCELERATION
-        _swipeSensitivity.value = sensitivity.coerceIn(0.6f, 2.5f)
+        val frameInterval = frameIntervalMillis.value
+        val frameModifier = when {
+            frameInterval > 28f -> 0.75f
+            frameInterval > 22f -> 0.9f
+            else -> 1f
+        }
+        _swipeSensitivity.value = (sensitivity * frameModifier).coerceIn(0.6f, 2.5f)
     }
 
     override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) = Unit
+
+    private fun startFrameMonitoring() {
+        if (isFrameCallbackRegistered) return
+        choreographer = Choreographer.getInstance().also {
+            frameDurations.clear()
+            _frameIntervalMillis.value = DEFAULT_FRAME_INTERVAL_MS
+            lastFrameTimeNanos = 0L
+            it.postFrameCallback(frameCallback)
+            isFrameCallbackRegistered = true
+        }
+    }
+
+    private fun stopFrameMonitoring() {
+        if (!isFrameCallbackRegistered) return
+        choreographer?.removeFrameCallback(frameCallback)
+        choreographer = null
+        isFrameCallbackRegistered = false
+        lastFrameTimeNanos = 0L
+        frameDurations.clear()
+        _frameIntervalMillis.value = DEFAULT_FRAME_INTERVAL_MS
+    }
+
+    internal fun updateFrameMetrics(frameDurationMillis: Float) {
+        if (frameDurationMillis <= 0f || frameDurationMillis.isNaN() || frameDurationMillis > 1_000f) {
+            return
+        }
+        frameDurations.addLast(frameDurationMillis)
+        while (frameDurations.size > MAX_TRACKED_FRAMES) {
+            frameDurations.removeFirst()
+        }
+        if (frameDurations.isEmpty()) {
+            _frameIntervalMillis.value = DEFAULT_FRAME_INTERVAL_MS
+        } else {
+            var sum = 0f
+            frameDurations.forEach { sum += it }
+            _frameIntervalMillis.value = sum / frameDurations.size
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- swap Adaptive Flow timing logic to `System.currentTimeMillis` and expose the wall clock for tests
- feed Choreographer frame pacing into sensitivity/preload heuristics and surface a testing hook
- add dedicated Gradle tasks plus README docs for running the frame-focused Robolectric tests

## Testing
- `./gradlew testDebugUnitTest` *(fails: SSLHandshakeException while downloading Gradle 8.7 distribution)*

------
https://chatgpt.com/codex/tasks/task_e_68d41f1c55dc832bbdc72edaede1835f