### PR TITLE
Fix missing material3 dynamic color dependency

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -108,7 +108,7 @@ dependencies {
     implementation("androidx.compose.ui:ui-tooling-preview")
     implementation("androidx.compose.foundation:foundation")
     implementation("androidx.compose.material3:material3")
-    implementation("androidx.compose.material3:material3-dynamic-color")
+    implementation("com.google.android.material:material-color-utilities:1.2.0")
     implementation("com.google.android.material:material:1.12.0")
     implementation("androidx.navigation:navigation-compose:2.8.0")
     implementation("androidx.datastore:datastore-preferences:1.1.1")


### PR DESCRIPTION
## Summary
- replace the removed `androidx.compose.material3:material3-dynamic-color` artifact with the `com.google.android.material:material-color-utilities` dependency so dynamic color utilities remain available when using the Compose BOM

## Testing
- ⚠️ `./gradlew testDebugUnitTest` *(fails: Gradle distribution download blocked by SSL certificate issue in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d4319880a8832ba3647217faa9ac76