### PR TITLE
Add PDF outline navigation and PrintManager export

### DIFF
--- a/app/src/main/kotlin/com/novapdf/reader/model/OutlineModels.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/model/OutlineModels.kt
@@ -1,0 +1,8 @@
+package com.novapdf.reader.model
+
+data class PdfOutlineNode(
+    val title: String,
+    val pageIndex: Int,
+    val children: List<PdfOutlineNode> = emptyList()
+)
+

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,4 +18,9 @@
     <string name="dynamic_color_unsupported">Dynamic colors require Android 12 or newer.</string>
     <string name="high_contrast_label">High contrast</string>
     <string name="high_contrast_description">Increase contrast for improved readability.</string>
+    <string name="pdf_outline">Outline</string>
+    <string name="outline_empty">This document does not include an outline.</string>
+    <string name="outline_page_label">Page %1$d</string>
+    <string name="export_document">Export or share</string>
+    <string name="export_failed">Unable to export the document. Try again.</string>
 </resources>


### PR DESCRIPTION
## Summary
- parse PDF outlines via `PdfDocumentRepository` and surface them through the viewer state
- add an outline navigator bottom sheet and PrintManager-based export action in the viewer UI
- introduce outline data models and supporting strings for the new interactions

## Testing
- `./gradlew testDebugUnitTest` *(fails: SSL handshake while downloading Gradle wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_68d43a52ca34832b823d4a95ac476f8c