### PR TITLE
Secure annotation persistence with encryption

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -117,6 +117,7 @@ dependencies {
     implementation("androidx.appcompat:appcompat:1.7.0")
     implementation("androidx.constraintlayout:constraintlayout-compose:1.0.1")
     implementation("androidx.work:work-runtime-ktx:2.9.0")
+    implementation("androidx.security:security-crypto:1.1.0-alpha06")
 
     implementation("androidx.room:room-runtime:2.6.1")
     implementation("androidx.room:room-ktx:2.6.1")

--- a/app/src/main/kotlin/com/novapdf/reader/data/AnnotationRepository.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/data/AnnotationRepository.kt
@@ -2,6 +2,9 @@ package com.novapdf.reader.data
 
 import android.content.Context
 import android.util.Base64
+import androidx.core.content.edit
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
 import com.novapdf.reader.model.AnnotationCommand
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -13,6 +16,18 @@ class AnnotationRepository(private val context: Context) {
     private val json = Json { prettyPrint = true }
     private val inMemoryAnnotations = mutableMapOf<String, MutableList<AnnotationCommand>>()
     private val lock = Any()
+    private val encryptedPreferences by lazy {
+        val masterKey = MasterKey.Builder(context)
+            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+            .build()
+        EncryptedSharedPreferences.create(
+            context,
+            PREFERENCES_FILE_NAME,
+            masterKey,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        )
+    }
 
     fun annotationsForDocument(documentId: String): List<AnnotationCommand> =
         synchronized(lock) { inMemoryAnnotations[documentId]?.toList().orEmpty() }
@@ -41,11 +56,25 @@ class AnnotationRepository(private val context: Context) {
             inMemoryAnnotations[documentId]?.toList()
         } ?: return@withContext null
         val encodedId = Base64.encodeToString(documentId.toByteArray(), Base64.URL_SAFE or Base64.NO_WRAP)
-        val outputDir = File(context.filesDir, "annotations").apply { mkdirs() }
-        val outputFile = File(outputDir, "$encodedId.json")
-        outputFile.writeText(json.encodeToString(annotations))
-        outputFile
+        val payload = json.encodeToString(annotations)
+        encryptedPreferences.edit(commit = true) {
+            putString(encodedId, payload)
+        }
+        preferenceFile(context)
     }
 
     fun trackedDocumentIds(): Set<String> = synchronized(lock) { inMemoryAnnotations.keys.toSet() }
+
+    companion object {
+        const val PREFERENCES_FILE_NAME = "annotation_repository"
+
+        fun preferenceFile(context: Context): File {
+            val appContext = context.applicationContext
+            val dataDir = appContext.applicationInfo.dataDir?.let(::File)
+                ?: appContext.filesDir.parentFile
+                ?: appContext.filesDir
+            val sharedPrefsDir = File(dataDir, "shared_prefs").apply { mkdirs() }
+            return File(sharedPrefsDir, "$PREFERENCES_FILE_NAME.xml")
+        }
+    }
 }

--- a/app/src/test/kotlin/com/novapdf/reader/data/AnnotationRepositoryTest.kt
+++ b/app/src/test/kotlin/com/novapdf/reader/data/AnnotationRepositoryTest.kt
@@ -7,6 +7,7 @@ import com.novapdf.reader.model.PointSnapshot
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -38,6 +39,10 @@ class AnnotationRepositoryTest {
 
         val file = repository.saveAnnotations(documentId)
         assertNotNull(file)
-        assertEquals(true, file!!.exists())
+        val prefsFile = file!!
+        assertEquals(true, prefsFile.exists())
+        val fileContents = prefsFile.readText()
+        assertFalse(fileContents.contains(documentId))
+        assertFalse(fileContents.contains("{"))
     }
 }


### PR DESCRIPTION
## Summary
- replace plain-text annotation exports with EncryptedSharedPreferences backed by an Android Keystore master key
- expose the encrypted preference file for tests and adjust tests to assert encrypted output
- add the AndroidX security crypto dependency required for EncryptedSharedPreferences

## Testing
- `./gradlew testDebugUnitTest` *(fails: SSLHandshakeException downloading Gradle wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_68d48d5ddb90832ba19a4818ca2fb657