### PR TITLE
Add XML fallback viewer for non-Compose devices

### DIFF
--- a/app/src/main/kotlin/com/novapdf/reader/legacy/LegacyPdfPageAdapter.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/legacy/LegacyPdfPageAdapter.kt
@@ -1,0 +1,156 @@
+package com.novapdf.reader.legacy
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Rect
+import android.util.SparseArray
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ImageView
+import android.widget.TextView
+import androidx.core.content.ContextCompat
+import androidx.core.util.forEach
+import androidx.core.util.set
+import androidx.core.view.isVisible
+import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.progressindicator.CircularProgressIndicator
+import com.novapdf.reader.PdfViewerViewModel
+import com.novapdf.reader.R
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlin.math.max
+
+private const val MIN_SCALE = 0.5f
+private const val MAX_SCALE = 3f
+
+class LegacyPdfPageAdapter(
+    private val context: Context,
+    private val scope: CoroutineScope,
+    private val viewModel: PdfViewerViewModel
+) : RecyclerView.Adapter<LegacyPdfPageViewHolder>() {
+
+    private val pageIndices = mutableListOf<Int>()
+    private val pageJobs = SparseArray<Job>()
+    private val bitmaps = SparseArray<Bitmap>()
+    private var currentDocumentId: String? = null
+
+    fun onDocumentChanged(documentId: String?, pageCount: Int) {
+        if (documentId == null) {
+            clear()
+            return
+        }
+        if (documentId != currentDocumentId) {
+            clear()
+            currentDocumentId = documentId
+        }
+        val newSize = max(0, pageCount)
+        pageIndices.clear()
+        repeat(newSize) { index ->
+            pageIndices.add(index)
+        }
+        notifyDataSetChanged()
+    }
+
+    fun clear() {
+        pageJobs.forEach { _, job -> job.cancel() }
+        pageJobs.clear()
+        bitmaps.clear()
+        pageIndices.clear()
+        currentDocumentId = null
+        notifyDataSetChanged()
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): LegacyPdfPageViewHolder {
+        val view = LayoutInflater.from(parent.context).inflate(R.layout.item_pdf_page, parent, false)
+        return LegacyPdfPageViewHolder(view)
+    }
+
+    override fun getItemCount(): Int = pageIndices.size
+
+    override fun onViewRecycled(holder: LegacyPdfPageViewHolder) {
+        super.onViewRecycled(holder)
+        val page = holder.boundPage
+        if (page != RecyclerView.NO_POSITION) {
+            pageJobs[page]?.cancel()
+        }
+    }
+
+    override fun onBindViewHolder(holder: LegacyPdfPageViewHolder, position: Int) {
+        val pageIndex = pageIndices[position]
+        holder.bind(pageIndex)
+        val cached = bitmaps[pageIndex]
+        if (cached != null && !cached.isRecycled) {
+            holder.showBitmap(cached)
+            return
+        }
+        holder.showLoading()
+        pageJobs[pageIndex]?.cancel()
+        val job = scope.launch {
+            val bitmap = renderPageBitmap(pageIndex)
+            withContext(Dispatchers.Main) {
+                if (holder.boundPage == pageIndex) {
+                    if (bitmap != null) {
+                        bitmaps[pageIndex] = bitmap
+                        holder.showBitmap(bitmap)
+                    } else {
+                        holder.showError(ContextCompat.getDrawable(context, R.drawable.ic_pdf))
+                    }
+                } else {
+                    bitmap?.recycle()
+                }
+            }
+        }
+        pageJobs[pageIndex] = job
+    }
+
+    private suspend fun renderPageBitmap(pageIndex: Int): Bitmap? {
+        val size = viewModel.requestPageSize(pageIndex) ?: return null
+        val metrics = context.resources.displayMetrics
+        val horizontalPadding = context.resources.getDimensionPixelSize(R.dimen.legacy_page_horizontal_margin) * 2
+        val targetWidth = max(1, metrics.widthPixels - horizontalPadding)
+        val scale = (targetWidth.toFloat() / size.width).coerceIn(MIN_SCALE, MAX_SCALE)
+        val rect = Rect(0, 0, size.width, size.height)
+        return viewModel.renderTile(pageIndex, rect, scale)
+    }
+
+    fun dispose() {
+        clear()
+    }
+}
+
+class LegacyPdfPageViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+    private val imageView: ImageView = itemView.findViewById(R.id.legacy_page_image)
+    private val progress: CircularProgressIndicator = itemView.findViewById(R.id.legacy_page_progress)
+    private val label: TextView = itemView.findViewById(R.id.legacy_page_label)
+
+    var boundPage: Int = RecyclerView.NO_POSITION
+        private set
+
+    fun bind(pageIndex: Int) {
+        boundPage = pageIndex
+        label.text = itemView.context.getString(R.string.legacy_pdf_page, pageIndex + 1)
+        label.isVisible = false
+    }
+
+    fun showLoading() {
+        progress.isVisible = true
+        imageView.setImageDrawable(null)
+        label.isVisible = false
+    }
+
+    fun showBitmap(bitmap: Bitmap) {
+        progress.isVisible = false
+        imageView.setImageBitmap(bitmap)
+        label.isVisible = true
+    }
+
+    fun showError(drawable: android.graphics.drawable.Drawable?) {
+        progress.isVisible = false
+        imageView.setImageDrawable(drawable)
+        label.isVisible = true
+    }
+}

--- a/app/src/main/res/drawable/legacy_page_label_background.xml
+++ b/app/src/main/res/drawable/legacy_page_label_background.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="12dp" />
+    <solid android:color="?attr/colorPrimary" />
+</shape>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/legacy_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
+    tools:context=".MainActivity">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/legacy_toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:background="?attr/colorSurface"
+        android:elevation="4dp"
+        android:theme="@style/ThemeOverlay.Material3.ActionBar"
+        app:title="@string/app_name" />
+
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginTop="?attr/actionBarSize"
+        android:paddingBottom="@dimen/legacy_page_vertical_margin">
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/legacy_page_list"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:clipToPadding="false"
+            android:paddingStart="@dimen/legacy_page_horizontal_margin"
+            android:paddingEnd="@dimen/legacy_page_horizontal_margin"
+            android:paddingTop="@dimen/legacy_page_vertical_margin"
+            android:scrollbarStyle="outsideOverlay"
+            tools:listitem="@layout/item_pdf_page" />
+
+        <LinearLayout
+            android:id="@+id/legacy_status_container"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:gravity="center"
+            android:orientation="vertical"
+            android:padding="24dp"
+            android:visibility="gone">
+
+            <TextView
+                android:id="@+id/legacy_status_text"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:text="@string/legacy_select_document"
+                android:textAppearance="@style/TextAppearance.Material3.BodyLarge"
+                android:textColor="?attr/colorOnSurfaceVariant" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/legacy_retry_button"
+                style="@style/Widget.Material3.Button.TonalButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:text="@string/legacy_retry"
+                android:visibility="gone" />
+        </LinearLayout>
+
+        <com.google.android.material.progressindicator.CircularProgressIndicator
+            android:id="@+id/legacy_progress"
+            style="@style/Widget.Material3.CircularProgressIndicator"
+            android:layout_width="@dimen/legacy_progress_size"
+            android:layout_height="@dimen/legacy_progress_size"
+            android:layout_gravity="center"
+            android:visibility="gone" />
+    </FrameLayout>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/item_pdf_page.xml
+++ b/app/src/main/res/layout/item_pdf_page.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginBottom="@dimen/legacy_page_vertical_margin">
+
+    <ImageView
+        android:id="@+id/legacy_page_image"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:adjustViewBounds="true"
+        android:contentDescription="@null"
+        android:scaleType="fitCenter"
+        tools:src="@drawable/ic_pdf" />
+
+    <com.google.android.material.progressindicator.CircularProgressIndicator
+        android:id="@+id/legacy_page_progress"
+        style="@style/Widget.Material3.CircularProgressIndicator"
+        android:layout_width="32dp"
+        android:layout_height="32dp"
+        android:layout_gravity="center"
+        android:visibility="gone" />
+
+    <TextView
+        android:id="@+id/legacy_page_label"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|end"
+        android:layout_margin="8dp"
+        android:background="@drawable/legacy_page_label_background"
+        android:paddingStart="8dp"
+        android:paddingEnd="8dp"
+        android:paddingTop="4dp"
+        android:paddingBottom="4dp"
+        android:textAppearance="@style/TextAppearance.Material3.LabelSmall"
+        android:textColor="?attr/colorOnPrimary"
+        android:visibility="gone"
+        tools:text="Page 1"
+        tools:visibility="visible" />
+
+</FrameLayout>

--- a/app/src/main/res/menu/fallback_viewer_actions.xml
+++ b/app/src/main/res/menu/fallback_viewer_actions.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/action_open"
+        android:title="@string/open_pdf"
+        app:showAsAction="always" />
+
+    <item
+        android:id="@+id/action_export"
+        android:title="@string/export_document"
+        app:showAsAction="never" />
+
+</menu>

--- a/app/src/main/res/values/bools.xml
+++ b/app/src/main/res/values/bools.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="config_use_compose">true</bool>
+</resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="legacy_page_horizontal_margin">16dp</dimen>
+    <dimen name="legacy_page_vertical_margin">12dp</dimen>
+    <dimen name="legacy_progress_size">48dp</dimen>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,4 +23,8 @@
     <string name="outline_page_label">Page %1$d</string>
     <string name="export_document">Export or share</string>
     <string name="export_failed">Unable to export the document. Try again.</string>
+    <string name="legacy_select_document">Open a PDF to start reading.</string>
+    <string name="legacy_error_loading">Something went wrong while opening the PDF.</string>
+    <string name="legacy_retry">Try again</string>
+    <string name="legacy_pdf_page">Page %1$d</string>
 </resources>


### PR DESCRIPTION
## Summary
- add a runtime switch in `MainActivity` to choose the Compose UI or a legacy XML viewer
- implement a RecyclerView-based legacy PDF page adapter that renders bitmaps through the existing view model
- provide XML layouts, menu resources, and configuration flags to host the fallback viewer and status messaging

## Testing
- ./gradlew testDebugUnitTest *(fails: Gradle wrapper download blocked by SSL handshake restrictions in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d490753170832b902a99a429b0eaf2