### PR TITLE
Fix performance test registration

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -147,27 +147,29 @@ kotlin {
     jvmToolchain(17)
 }
 
-val debugUnitTest = tasks.named<Test>("testDebugUnitTest")
+afterEvaluate {
+    val debugUnitTest = tasks.named<Test>("testDebugUnitTest")
 
-tasks.register<Test>("adaptiveFlowPerformance") {
-    group = "performance"
-    description = "Runs Adaptive Flow timing regression checks."
-    testClassesDirs = debugUnitTest.get().testClassesDirs
-    classpath = debugUnitTest.get().classpath
-    useJUnitPlatform()
-    filter {
-        includeTestsMatching("com.novapdf.reader.AdaptiveFlowManagerTest.readingSpeedRespondsToPageChanges")
+    tasks.register<Test>("adaptiveFlowPerformance") {
+        group = "performance"
+        description = "Runs Adaptive Flow timing regression checks."
+        testClassesDirs = debugUnitTest.get().testClassesDirs
+        classpath = debugUnitTest.get().classpath
+        useJUnitPlatform()
+        filter {
+            includeTestsMatching("com.novapdf.reader.AdaptiveFlowManagerTest.readingSpeedRespondsToPageChanges")
+        }
     }
-}
 
-tasks.register<Test>("frameMonitoringPerformance") {
-    group = "performance"
-    description = "Executes frame monitoring diagnostics for Adaptive Flow."
-    testClassesDirs = debugUnitTest.get().testClassesDirs
-    classpath = debugUnitTest.get().classpath
-    useJUnitPlatform()
-    filter {
-        includeTestsMatching("com.novapdf.reader.AdaptiveFlowManagerTest.frameMetricsReactToJank")
+    tasks.register<Test>("frameMonitoringPerformance") {
+        group = "performance"
+        description = "Executes frame monitoring diagnostics for Adaptive Flow."
+        testClassesDirs = debugUnitTest.get().testClassesDirs
+        classpath = debugUnitTest.get().classpath
+        useJUnitPlatform()
+        filter {
+            includeTestsMatching("com.novapdf.reader.AdaptiveFlowManagerTest.frameMetricsReactToJank")
+        }
+        shouldRunAfter("adaptiveFlowPerformance")
     }
-    shouldRunAfter("adaptiveFlowPerformance")
 }


### PR DESCRIPTION
## Summary
- defer performance test registration until after evaluation so the debug unit test task exists

## Testing
- `./gradlew testDebugUnitTest -x lint` *(fails: SSL handshake preventing Gradle distribution download)*

------
https://chatgpt.com/codex/tasks/task_e_68d4929e93c0832b8eff6d9005dfecd7