### PR TITLE
Inline encoded sample PDF fixture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,40 +1,26 @@
 # NovaPDF Reader
 
-NovaPDF Reader is a Jetpack Compose Android application that experiments with "Adaptive Flow Reading" for fluid PDF consumption,
-annotation, and accessibility enhancements on modern Android devices.
+NovaPDF Reader is a Jetpack Compose Android application that experiments with "Adaptive Flow Reading" for fluid PDF consumption, annotation, and accessibility enhancements on modern Android devices.
 
 ## Adaptive Flow performance tooling
 
-Adaptive Flow now records frame pacing through `Choreographer` on the main thread so that preloading logic can back off when the
-UI is under pressure. Two dedicated Gradle tasks are available to exercise the timing heuristics and frame monitoring in
-isolation:
+Adaptive Flow now records frame pacing through `Choreographer` on the main thread so that preloading logic can back off when the UI is under pressure. Two dedicated Gradle tasks are available to exercise the timing heuristics and frame monitoring in isolation:
 
 ```
 ./gradlew adaptiveFlowPerformance
 ./gradlew frameMonitoringPerformance
 ```
 
-Both tasks reuse the Robolectric unit tests backing the Adaptive Flow manager and give fast feedback without running the full
-unit test suite.
+Both tasks reuse the Robolectric unit tests backing the Adaptive Flow manager and give fast feedback without running the full unit test suite.
 
 ## Sample PDF fixture
 
-Automated tests and screenshot generation expect a tiny CC0 1.0 licensed document that lives outside of the repository on S3.
-By default the project points at `https://novapdf-sample-assets.s3.us-west-2.amazonaws.com/sample.pdf`, a CC0 1.0 document sized
-specifically for automated smoke tests. If you need to swap in a different document, provide the HTTPS location of that object
-through the Gradle property `-PnovapdfSamplePdfUrl=` when invoking instrumentation workflows (for example,
-`./gradlew connectedCheck -PnovapdfSamplePdfUrl=https://your-bucket.s3.amazonaws.com/sample.pdf`). The instrumentation runner
-receives the same URL through its arguments, downloads the file into the test cache, and renders it to validate the viewer
-pipeline without shipping binary fixtures in source control.
+Automated tests and screenshot generation rely on a tiny CC0 1.0 licensed document that now ships inline with the instrumentation test sources. The encoded fixture is decoded directly into the device cache before opening it in the viewer so rendering can be validated without relying on external network services or bundling binary blobs in git.
 
-See `docs/sample-pdf-license.md` for the redistribution notice covering the hosted document.
+See `docs/sample-pdf-license.md` for the redistribution notice covering the bundled document.
 
 ## Gradle wrapper bootstrap
 
-Binary assets such as the `gradle-wrapper.jar` are intentionally not stored in this repository. Instead, the wrapper JAR is stored
-as a Base64 text file at `gradle/wrapper/gradle-wrapper.jar.base64`. The included `gradlew` and `gradlew.bat` scripts automatically
-decode this archive to `gradle/wrapper/gradle-wrapper.jar` (Gradle 8.5) the first time you run them.
+Binary assets such as the `gradle-wrapper.jar` are intentionally not stored in this repository. Instead, the wrapper JAR is stored as a Base64 text file at `gradle/wrapper/gradle-wrapper.jar.base64`. The included `gradlew` and `gradlew.bat` scripts automatically decode this archive to `gradle/wrapper/gradle-wrapper.jar` (Gradle 8.5) the first time you run them.
 
-If your environment blocks execution of Python, PowerShell, or the `base64` utility, manually decode the file or download the wrapper
-from `https://services.gradle.org/distributions/gradle-8.5-bin.zip` and copy `gradle-8.5/lib/plugins/gradle-wrapper-8.5.jar`
-to `gradle/wrapper/gradle-wrapper.jar` before invoking Gradle.
+If your environment blocks execution of Python, PowerShell, or the `base64` utility, manually decode the file or download the wrapper from `https://services.gradle.org/distributions/gradle-8.5-bin.zip` and copy `gradle-8.5/lib/plugins/gradle-wrapper-8.5.jar` to `gradle/wrapper/gradle-wrapper.jar` before invoking Gradle.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,10 +8,6 @@ plugins {
     id("org.jetbrains.kotlin.kapt")
 }
 
-val defaultSamplePdfUrl = providers
-    .gradleProperty("novapdfSamplePdfUrl")
-    .orElse("https://novapdf-sample-assets.s3.us-west-2.amazonaws.com/sample.pdf")
-
 android {
     namespace = "com.novapdf.reader"
     compileSdk = 35
@@ -26,11 +22,6 @@ android {
         vectorDrawables.useSupportLibrary = true
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
-        val samplePdfUrl = defaultSamplePdfUrl.get()
-        buildConfigField("String", "SAMPLE_PDF_URL", "\"$samplePdfUrl\"")
-        if (samplePdfUrl.isNotBlank()) {
-            testInstrumentationRunnerArguments["samplePdfUrl"] = samplePdfUrl
-        }
     }
 
     buildTypes {

--- a/app/src/androidTest/kotlin/com/novapdf/reader/SampleDocument.kt
+++ b/app/src/androidTest/kotlin/com/novapdf/reader/SampleDocument.kt
@@ -2,113 +2,93 @@ package com.novapdf.reader
 
 import android.content.Context
 import androidx.core.net.toUri
-import androidx.test.platform.app.InstrumentationRegistry
-import com.novapdf.reader.BuildConfig
 import java.io.File
 import java.io.IOException
-import java.net.HttpURLConnection
-import java.net.URL
+import java.util.Base64
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
 internal object SampleDocument {
     private const val CACHE_FILE_NAME = "sample.pdf"
-    private const val ARG_SAMPLE_URL = "samplePdfUrl"
-    private const val SYSTEM_PROPERTY_SAMPLE_URL = "novapdf.samplePdfUrl"
 
     suspend fun installIntoCache(context: Context): android.net.Uri = withContext(Dispatchers.IO) {
-        val sampleUrl = resolveSampleUrl()
-            ?: throw IllegalStateException(
-                "No sample PDF URL configured. Provide the instrumentation argument \"$ARG_SAMPLE_URL\" or Gradle property \"novapdfSamplePdfUrl\" pointing to an S3 object."
-            )
-
         val appContext = context.applicationContext
         val cacheFile = File(appContext.cacheDir, CACHE_FILE_NAME)
         cacheFile.parentFile?.mkdirs()
 
-        if (!cacheFile.exists() || cacheFile.length() == 0L) {
-            downloadToFile(sampleUrl, cacheFile)
+        if (!cacheFile.exists() || cacheFile.length() != SAMPLE_PDF_BYTES.size.toLong()) {
+            writeFixtureTo(cacheFile)
         }
 
         cacheFile.toUri()
     }
 
-    private fun resolveSampleUrl(): String? {
-        val instrumentationArgs = InstrumentationRegistry.getArguments()
-        val fromArgs = instrumentationArgs.getString(ARG_SAMPLE_URL)?.takeIf { it.isNotBlank() }
-        if (fromArgs != null) {
-            return fromArgs
-        }
-
-        val fromEnv = System.getenv("NOVAPDF_SAMPLE_PDF_URL")?.takeIf { it.isNotBlank() }
-        if (fromEnv != null) {
-            return fromEnv
-        }
-
-        val fromSystemProperty = System.getProperty(SYSTEM_PROPERTY_SAMPLE_URL)?.takeIf { it.isNotBlank() }
-        if (fromSystemProperty != null) {
-            return fromSystemProperty
-        }
-
-        return BuildConfig.SAMPLE_PDF_URL.takeIf { it.isNotBlank() }
-    }
-
-    private fun downloadToFile(sourceUrl: String, destination: File) {
+    private fun writeFixtureTo(destination: File) {
         val parentDir = destination.parentFile ?: throw IOException("Missing cache directory for sample PDF")
-        if (!parentDir.exists()) {
-            parentDir.mkdirs()
+        if (!parentDir.exists() && !parentDir.mkdirs()) {
+            throw IOException("Unable to create cache directory for sample PDF")
         }
 
-        val connection = (URL(sourceUrl).openConnection() as HttpURLConnection).apply {
-            connectTimeout = 10_000
-            readTimeout = 15_000
-            instanceFollowRedirects = true
+        val tempFile = File(parentDir, destination.name + ".tmp")
+        if (tempFile.exists() && !tempFile.delete()) {
+            throw IOException("Unable to clear stale cached sample PDF")
         }
 
-        try {
-            val responseCode = connection.responseCode
-            if (responseCode != HttpURLConnection.HTTP_OK) {
-                val message = buildString {
-                    append("Failed to download sample PDF from ")
-                    append(sourceUrl)
-                    append(". HTTP ")
-                    append(responseCode)
-                    connection.responseMessage?.takeIf { it.isNotBlank() }?.let { reason ->
-                        append(" (")
-                        append(reason)
-                        append(')')
-                    }
-                }
-                throw IOException(message)
-            }
+        tempFile.outputStream().use { output ->
+            output.write(SAMPLE_PDF_BYTES)
+            output.flush()
+        }
 
-            val tempFile = File(parentDir, destination.name + ".download")
-            if (tempFile.exists() && !tempFile.delete()) {
-                throw IOException("Unable to clear stale temporary download file")
-            }
+        if (tempFile.length() != SAMPLE_PDF_BYTES.size.toLong()) {
+            tempFile.delete()
+            throw IOException("Bundled sample PDF fixture was not written correctly")
+        }
 
-            connection.inputStream.use { input ->
-                tempFile.outputStream().use { output ->
-                    input.copyTo(output)
-                }
-            }
+        if (destination.exists() && !destination.delete()) {
+            tempFile.delete()
+            throw IOException("Unable to replace cached sample PDF")
+        }
 
-            if (tempFile.length() == 0L) {
-                tempFile.delete()
-                throw IOException("Downloaded sample PDF is empty")
-            }
-
-            if (destination.exists() && !destination.delete()) {
-                tempFile.delete()
-                throw IOException("Unable to replace cached sample PDF")
-            }
-
-            if (!tempFile.renameTo(destination)) {
-                tempFile.delete()
-                throw IOException("Unable to move downloaded sample PDF into cache")
-            }
-        } finally {
-            connection.disconnect()
+        if (!tempFile.renameTo(destination)) {
+            tempFile.delete()
+            throw IOException("Unable to move bundled sample PDF into cache")
         }
     }
+
+    private val SAMPLE_PDF_BYTES: ByteArray by lazy {
+        val normalized = SAMPLE_PDF_BASE64.filterNot(Char::isWhitespace)
+        Base64.getDecoder().decode(normalized)
+    }
+
+    private const val SAMPLE_PDF_BASE64 = """
+JVBERi0xLjMKJZOMi54gUmVwb3J0TGFiIEdlbmVyYXRlZCBQREYgZG9jdW1lbnQgaHR0cDovL3d3
+dy5yZXBvcnRsYWIuY29tCjEgMCBvYmoKPDwKL0YxIDIgMCBSIC9GMiAzIDAgUgo+PgplbmRvYmoK
+MiAwIG9iago8PAovQmFzZUZvbnQgL0hlbHZldGljYSAvRW5jb2RpbmcgL1dpbkFuc2lFbmNvZGlu
+ZyAvTmFtZSAvRjEgL1N1YnR5cGUgL1R5cGUxIC9UeXBlIC9Gb250Cj4+CmVuZG9iagozIDAgb2Jq
+Cjw8Ci9CYXNlRm9udCAvSGVsdmV0aWNhLUJvbGQgL0VuY29kaW5nIC9XaW5BbnNpRW5jb2Rpbmcg
+L05hbWUgL0YyIC9TdWJ0eXBlIC9UeXBlMSAvVHlwZSAvRm9udAo+PgplbmRvYmoKNCAwIG9iago8
+PAovQ29udGVudHMgOCAwIFIgL01lZGlhQm94IFsgMCAwIDYxMiA3OTIgXSAvUGFyZW50IDcgMCBS
+IC9SZXNvdXJjZXMgPDwKL0ZvbnQgMSAwIFIgL1Byb2NTZXQgWyAvUERGIC9UZXh0IC9JbWFnZUIg
+L0ltYWdlQyAvSW1hZ2VJIF0KPj4gL1JvdGF0ZSAwIC9UcmFucyA8PAoKPj4gCiAgL1R5cGUgL1Bh
+Z2UKPj4KZW5kb2JqCjUgMCBvYmoKPDwKL1BhZ2VNb2RlIC9Vc2VOb25lIC9QYWdlcyA3IDAgUiAv
+VHlwZSAvQ2F0YWxvZwo+PgplbmRvYmoKNiAwIG9iago8PAovQXV0aG9yIChhbm9ueW1vdXMpIC9D
+cmVhdGlvbkRhdGUgKEQ6MjAyNTA5MjUwMDU3NDcrMDAnMDAnKSAvQ3JlYXRvciAoUmVwb3J0TGFi
+IFBERiBMaWJyYXJ5IC0gd3d3LnJlcG9ydGxhYi5jb20pIC9LZXl3b3JkcyAoKSAvTW9kRGF0ZSAo
+RDoyMDI1MDkyNTAwNTc0NyswMCcwMCcpIC9Qcm9kdWNlciAoUmVwb3J0TGFiIFBERiBMaWJyYXJ5
+IC0gd3d3LnJlcG9ydGxhYi5jb20pIAogIC9TdWJqZWN0ICh1bnNwZWNpZmllZCkgL1RpdGxlICh1
+bnRpdGxlZCkgL1RyYXBwZWQgL0ZhbHNlCj4+CmVuZG9iago3IDAgb2JqCjw8Ci9Db3VudCAxIC9L
+aWRzIFsgNCAwIFIgXSAvVHlwZSAvUGFnZXMKPj4KZW5kb2JqCjggMCBvYmoKPDwKL0ZpbHRlciBb
+IC9BU0NJSTg1RGVjb2RlIC9GbGF0ZURlY29kZSBdIC9MZW5ndGggMjQ3Cj4+CnN0cmVhbQpHYXJw
+Jl8uaiQrJi1oKCk6W29ORCYkJCJwSEMhLFwuN05oMCtjYyFDREJiS09wJGtiL0JWQHRbM1cuKks2
+T11qUlFzKWlmLzAtJmYiKFU7NTBRIzpVSUdpcUBDMlJKN2hxVGlRYD9SPCNAVydBW19ZImFxVk5d
+J1BnQm5uVysrTkpYbUshIS1HRF1gSjFPSi0qYXQoZDtjRVpcO1drQEFNJVtlRlsqc0g8LiViX05f
+UyhIYDFQYkI/MCktQk9FIV86WCNvRyNoK1ZoajdVa1glOzYmMk0zW18vV2hpMWFqUjQzVFkyUyY0
+aVZtbypwWV1xQjhuUX4+ZW5kc3RyZWFtCmVuZG9iagp4cmVmCjAgOQowMDAwMDAwMDAwIDY1NTM1
+IGYgCjAwMDAwMDAwNzMgMDAwMDAgbiAKMDAwMDAwMDExNCAwMDAwMCBuIAowMDAwMDAwMjIxIDAw
+MDAwIG4gCjAwMDAwMDAzMzMgMDAwMDAgbiAKMDAwMDAwMDUyNiAwMDAwMCBuIAowMDAwMDAwNTk0
+IDAwMDAwIG4gCjAwMDAwMDA4OTAgMDAwMDAgbiAKMDAwMDAwMDk0OSAwMDAwMCBuIAp0cmFpbGVy
+Cjw8Ci9JRCAKWzw5ODI4NGY0ZWRkNDQ5MTM2MWYyY2Q1ZDViOGNkYjU4ZD48OTgyODRmNGVkZDQ0
+OTEzNjFmMmNkNWQ1YjhjZGI1OGQ+XQolIFJlcG9ydExhYiBnZW5lcmF0ZWQgUERGIGRvY3VtZW50
+IC0tIGRpZ2VzdCAoaHR0cDovL3d3dy5yZXBvcnRsYWIuY29tKQoKL0luZm8gNiAwIFIKL1Jvb3Qg
+NSAwIFIKL1NpemUgOQo+PgpzdGFydHhyZWYKMTI4NgolJUVPRgo="""
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-
-    <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <!-- MANAGE_EXTERNAL_STORAGE is declared so API 30+ users can opt in from the explicit
          settings screen launched by MainActivity. Keeping the permission behind that settings

--- a/app/src/main/assets/README.md
+++ b/app/src/main/assets/README.md
@@ -1,6 +1,3 @@
 # Assets Directory
 
-This directory intentionally does not store binary fixtures. Instrumentation tests fetch the CC0 1.0 sample PDF from S3 at
-runtime (see the repository README for configuration details) and place it in the device cache instead.
-
-Feel free to drop additional local test documents here while iterating, but do not commit them to the repository.
+This directory intentionally does not store binary fixtures that ship in production builds. Instrumentation tests rely on a CC0 1.0 sample PDF encoded directly in the test sources and copy it into the device cache during execution. Feel free to drop additional local test documents here while iterating, but do not commit them to the repository.

--- a/docs/sample-pdf-license.md
+++ b/docs/sample-pdf-license.md
@@ -1,5 +1,3 @@
 # Sample PDF License
 
-The sample PDF hosted at `https://novapdf-sample-assets.s3.us-west-2.amazonaws.com/sample.pdf` is dedicated to the public domain
-under [Creative Commons CC0 1.0](https://creativecommons.org/publicdomain/zero/1.0/). The document is purpose-built for automated
-workflows and may be redistributed without restriction.
+The bundled sample PDF decoded by the instrumentation tests is dedicated to the public domain under [Creative Commons CC0 1.0](https://creativecommons.org/publicdomain/zero/1.0/). The Base64 representation checked into `app/src/androidTest/kotlin/com/novapdf/reader/SampleDocument.kt` was created specifically for automated workflows and may be redistributed without restriction.


### PR DESCRIPTION
## Summary
- embed the CC0 sample PDF bytes directly in the instrumentation helper and write them to cache when needed
- remove the androidTest asset directory so the repository no longer tracks binary fixtures
- refresh documentation to point to the encoded fixture checked into source control

## Testing
- `./gradlew testDebugUnitTest` *(fails: SSLHandshakeException while downloading Gradle distribution)*

------
https://chatgpt.com/codex/tasks/task_e_68d4932ca518832ba49337b71c26b3c4