### PR TITLE
Add baseline profile module and macrobenchmark tasks

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -35,6 +35,12 @@ android {
                 "proguard-rules.pro"
             )
         }
+        create("benchmark") {
+            initWith(getByName("release"))
+            matchingFallbacks += listOf("release")
+            signingConfig = signingConfigs.getByName("debug")
+            isDebuggable = true
+        }
     }
 
     buildFeatures {
@@ -110,6 +116,7 @@ dependencies {
     implementation("androidx.constraintlayout:constraintlayout-compose:1.0.1")
     implementation("androidx.work:work-runtime-ktx:2.9.0")
     implementation("androidx.security:security-crypto:1.1.0-alpha06")
+    implementation("androidx.profileinstaller:profileinstaller:1.3.1")
 
     implementation("androidx.room:room-runtime:2.6.1")
     implementation("androidx.room:room-ktx:2.6.1")
@@ -133,6 +140,7 @@ dependencies {
     androidTestImplementation("androidx.compose.ui:ui-test-junit4")
     debugImplementation("androidx.compose.ui:ui-tooling")
     debugImplementation("androidx.compose.ui:ui-test-manifest")
+    baselineProfile(project(":baselineprofile"))
 }
 
 kotlin {

--- a/baselineprofile/build.gradle.kts
+++ b/baselineprofile/build.gradle.kts
@@ -1,0 +1,76 @@
+import com.android.build.api.dsl.TestExtension
+
+plugins {
+    id("com.android.test")
+    id("org.jetbrains.kotlin.android")
+    id("androidx.baselineprofile")
+}
+
+android {
+    namespace = "com.novapdf.reader.baselineprofile"
+    compileSdk = 35
+
+    defaultConfig {
+        minSdk = 24
+        targetSdk = 35
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    buildTypes {
+        create("benchmark") {
+            isDebuggable = true
+        }
+    }
+
+    targetProjectPath = ":app"
+    testBuildType = "benchmark"
+    experimentalProperties["android.experimental.self-instrumenting"] = true
+}
+
+baselineProfile {
+    useConnectedDevices = true
+}
+
+dependencies {
+    implementation(project(":app"))
+    implementation("androidx.test.ext:junit:1.1.5")
+    implementation("androidx.test.espresso:espresso-core:3.5.1")
+    implementation("androidx.test.uiautomator:uiautomator:2.3.0")
+    implementation("androidx.test:runner:1.5.2")
+    implementation("androidx.test:rules:1.5.0")
+    implementation("androidx.benchmark:benchmark-macro-junit4:1.2.4")
+    implementation("androidx.profileinstaller:profileinstaller:1.3.1")
+}
+
+val testExtension = extensions.getByType<TestExtension>()
+
+tasks.register("frameRateBenchmark") {
+    group = "performance"
+    description = "Collects frame rate metrics using Macrobenchmark instrumentation."
+    dependsOn("connectedBenchmarkAndroidTest")
+}
+
+tasks.register("memoryBenchmark") {
+    group = "performance"
+    description = "Collects memory usage metrics using Macrobenchmark instrumentation."
+    dependsOn("connectedBenchmarkAndroidTest")
+}
+
+tasks.register("startupBenchmark") {
+    group = "performance"
+    description = "Measures cold startup timing using Macrobenchmark instrumentation."
+    dependsOn("connectedBenchmarkAndroidTest")
+}
+
+gradle.taskGraph.whenReady { taskGraph ->
+    val arguments = testExtension.defaultConfig.testInstrumentationRunnerArguments
+    when {
+        taskGraph.hasTask(":baselineprofile:frameRateBenchmark") ->
+            arguments["annotation"] = "com.novapdf.reader.baselineprofile.annotations.FrameRateMetric"
+        taskGraph.hasTask(":baselineprofile:memoryBenchmark") ->
+            arguments["annotation"] = "com.novapdf.reader.baselineprofile.annotations.MemoryMetric"
+        taskGraph.hasTask(":baselineprofile:startupBenchmark") ->
+            arguments["annotation"] = "com.novapdf.reader.baselineprofile.annotations.StartupMetric"
+        else -> arguments.remove("annotation")
+    }
+}

--- a/baselineprofile/src/main/java/com/novapdf/reader/baselineprofile/Annotations.kt
+++ b/baselineprofile/src/main/java/com/novapdf/reader/baselineprofile/Annotations.kt
@@ -1,0 +1,13 @@
+package com.novapdf.reader.baselineprofile
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class FrameRateMetric
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class MemoryMetric
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class StartupMetric

--- a/baselineprofile/src/main/java/com/novapdf/reader/baselineprofile/BaselineProfileGenerator.kt
+++ b/baselineprofile/src/main/java/com/novapdf/reader/baselineprofile/BaselineProfileGenerator.kt
@@ -1,0 +1,30 @@
+package com.novapdf.reader.baselineprofile
+
+import androidx.benchmark.macro.ExperimentalBaselineProfilesApi
+import androidx.benchmark.macro.junit4.BaselineProfileRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@LargeTest
+@RunWith(AndroidJUnit4::class)
+class BaselineProfileGenerator {
+
+    @get:Rule
+    val baselineProfileRule = BaselineProfileRule()
+
+    @OptIn(ExperimentalBaselineProfilesApi::class)
+    @Test
+    fun generate() = baselineProfileRule.collectBaselineProfile(
+        packageName = TARGET_PACKAGE
+    ) {
+        startActivityAndWait()
+        device.waitForIdle()
+    }
+
+    private companion object {
+        const val TARGET_PACKAGE = "com.novapdf.reader"
+    }
+}

--- a/baselineprofile/src/main/java/com/novapdf/reader/baselineprofile/BenchmarkScenarios.kt
+++ b/baselineprofile/src/main/java/com/novapdf/reader/baselineprofile/BenchmarkScenarios.kt
@@ -1,0 +1,31 @@
+package com.novapdf.reader.baselineprofile
+
+import androidx.benchmark.macro.MacrobenchmarkScope
+import androidx.test.uiautomator.By
+import androidx.test.uiautomator.Direction
+import androidx.test.uiautomator.Until
+
+internal const val TARGET_PACKAGE = "com.novapdf.reader"
+
+internal fun MacrobenchmarkScope.launchReaderAndAwait() {
+    pressHome()
+    startActivityAndWait()
+    device.wait(Until.hasObject(By.pkg(TARGET_PACKAGE).depth(0)), 5_000)
+    device.waitForIdle()
+}
+
+internal fun MacrobenchmarkScope.exerciseReaderContent() {
+    val scrollable = device.findObject(By.scrollable(true))
+    if (scrollable != null) {
+        scrollable.setGestureMargin(device.displayWidth / 10)
+        scrollable.scroll(Direction.DOWN, 1.0f)
+        device.waitForIdle()
+        scrollable.scroll(Direction.UP, 1.0f)
+    } else {
+        val centerX = device.displayWidth / 2
+        val centerY = device.displayHeight / 2
+        device.swipe(centerX, centerY, centerX, (centerY * 0.5).toInt(), 30)
+        device.swipe(centerX, (centerY * 0.5).toInt(), centerX, centerY, 30)
+    }
+    device.waitForIdle()
+}

--- a/baselineprofile/src/main/java/com/novapdf/reader/baselineprofile/FrameRateBenchmark.kt
+++ b/baselineprofile/src/main/java/com/novapdf/reader/baselineprofile/FrameRateBenchmark.kt
@@ -1,0 +1,30 @@
+package com.novapdf.reader.baselineprofile
+
+import androidx.benchmark.macro.FrameTimingMetric
+import androidx.benchmark.macro.StartupMode
+import androidx.benchmark.macro.junit4.MacrobenchmarkRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@LargeTest
+@RunWith(AndroidJUnit4::class)
+class FrameRateBenchmark {
+
+    @get:Rule
+    val benchmarkRule = MacrobenchmarkRule()
+
+    @FrameRateMetric
+    @Test
+    fun scrollDocument() = benchmarkRule.measureRepeated(
+        packageName = TARGET_PACKAGE,
+        metrics = listOf(FrameTimingMetric()),
+        iterations = 5,
+        startupMode = StartupMode.COLD
+    ) {
+        launchReaderAndAwait()
+        exerciseReaderContent()
+    }
+}

--- a/baselineprofile/src/main/java/com/novapdf/reader/baselineprofile/MemoryBenchmark.kt
+++ b/baselineprofile/src/main/java/com/novapdf/reader/baselineprofile/MemoryBenchmark.kt
@@ -1,0 +1,30 @@
+package com.novapdf.reader.baselineprofile
+
+import androidx.benchmark.macro.MemoryUsageMetric
+import androidx.benchmark.macro.StartupMode
+import androidx.benchmark.macro.junit4.MacrobenchmarkRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@LargeTest
+@RunWith(AndroidJUnit4::class)
+class MemoryBenchmark {
+
+    @get:Rule
+    val benchmarkRule = MacrobenchmarkRule()
+
+    @MemoryMetric
+    @Test
+    fun coldStartMemory() = benchmarkRule.measureRepeated(
+        packageName = TARGET_PACKAGE,
+        metrics = listOf(MemoryUsageMetric()),
+        iterations = 3,
+        startupMode = StartupMode.COLD
+    ) {
+        launchReaderAndAwait()
+        exerciseReaderContent()
+    }
+}

--- a/baselineprofile/src/main/java/com/novapdf/reader/baselineprofile/StartupBenchmark.kt
+++ b/baselineprofile/src/main/java/com/novapdf/reader/baselineprofile/StartupBenchmark.kt
@@ -1,0 +1,29 @@
+package com.novapdf.reader.baselineprofile
+
+import androidx.benchmark.macro.StartupMode
+import androidx.benchmark.macro.StartupTimingMetric
+import androidx.benchmark.macro.junit4.MacrobenchmarkRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@LargeTest
+@RunWith(AndroidJUnit4::class)
+class StartupBenchmark {
+
+    @get:Rule
+    val benchmarkRule = MacrobenchmarkRule()
+
+    @StartupMetric
+    @Test
+    fun coldStartup() = benchmarkRule.measureRepeated(
+        packageName = TARGET_PACKAGE,
+        metrics = listOf(StartupTimingMetric()),
+        iterations = 5,
+        startupMode = StartupMode.COLD
+    ) {
+        launchReaderAndAwait()
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("com.android.application") version "8.5.0" apply false
     id("org.jetbrains.kotlin.android") version "1.9.24" apply false
     id("org.jetbrains.kotlin.plugin.serialization") version "1.9.24" apply false
+    id("androidx.baselineprofile") version "1.2.4" apply false
 }
 
 tasks.register("clean", Delete::class) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,5 +8,6 @@ kotlin.code.style=official
 android.useAndroidX=true
 android.enableJetifier=false
 android.nonTransitiveRClass=true
+android.experimental.art-profile-r8-rewriting=true
 org.gradle.jvm.toolchain.installations.auto-download=true
 org.gradle.jvm.toolchain.installations.auto-detect=true

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,3 +16,4 @@ dependencyResolutionManagement {
 
 rootProject.name = "NovaPDFReader"
 include(":app")
+include(":baselineprofile")


### PR DESCRIPTION
## Summary
- add a dedicated `baselineprofile` module that generates baseline profiles and hosts macrobenchmark coverage for frame timing, memory, and startup metrics
- wire the application to the new performance module via a benchmark build type, profile installer dependency, and baseline profile artifact packaging
- enable ART profile rewriting and expose convenient Gradle entry points for each performance metric run

## Testing
- `./gradlew :app:tasks --all` *(fails: unable to download Gradle distribution due to SSL handshake restrictions in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d49b486528832babbe7964d91e42c0