### PR TITLE
Apply baseline profile plugin to app module

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -31,6 +31,7 @@ plugins {
     id("org.jetbrains.kotlin.android")
     id("org.jetbrains.kotlin.plugin.serialization")
     id("org.jetbrains.kotlin.kapt")
+    id("androidx.baselineprofile")
 }
 
 android {


### PR DESCRIPTION
## Summary
- apply the androidx.baselineprofile Gradle plugin to the app module so the baselineProfile configuration is available

## Testing
- ./gradlew :app:help *(fails: gradle wrapper download blocked by SSL certificate issue in runner environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d49faa1d44832b971c7e4ee1d74a57