### PR TITLE
Replace MockK with Mockito in unit tests

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -181,7 +181,8 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1")
 
     testImplementation("org.junit.jupiter:junit-jupiter:5.10.3")
-    testImplementation("io.mockk:mockk:1.13.12")
+    testImplementation("org.mockito.kotlin:mockito-kotlin:5.2.1")
+    testImplementation("org.mockito:mockito-inline:5.11.0")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.1")
     testImplementation("org.robolectric:robolectric:4.12.1")
     testImplementation("junit:junit:4.13.2")

--- a/app/src/test/kotlin/com/novapdf/reader/PdfViewerViewModelSearchTest.kt
+++ b/app/src/test/kotlin/com/novapdf/reader/PdfViewerViewModelSearchTest.kt
@@ -13,11 +13,6 @@ import com.novapdf.reader.data.BookmarkManager
 import com.novapdf.reader.data.PdfDocumentRepository
 import com.novapdf.reader.data.PdfDocumentSession
 import com.novapdf.reader.work.DocumentMaintenanceScheduler
-import io.mockk.every
-import io.mockk.just
-import io.mockk.mockk
-import io.mockk.runs
-import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -32,6 +27,11 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 
 @RunWith(RobolectricTestRunner::class)
 class PdfViewerViewModelSearchTest {
@@ -52,33 +52,27 @@ class PdfViewerViewModelSearchTest {
     @Config(sdk = [34], application = TestPdfApp::class)
     fun `performSearch extracts text runs on Api 34`() = runTest {
         val app = TestPdfApp.getInstance()
-        val annotationRepository = mockk<AnnotationRepository>()
-        val pdfRepository = mockk<PdfDocumentRepository>()
-        val adaptiveFlowManager = mockk<AdaptiveFlowManager>()
-        val bookmarkManager = mockk<BookmarkManager>()
-        val maintenanceScheduler = mockk<DocumentMaintenanceScheduler>(relaxed = true)
+        val annotationRepository = mock<AnnotationRepository>()
+        val pdfRepository = mock<PdfDocumentRepository>()
+        val adaptiveFlowManager = mock<AdaptiveFlowManager>()
+        val bookmarkManager = mock<BookmarkManager>()
+        val maintenanceScheduler = mock<DocumentMaintenanceScheduler>()
 
         val readingSpeed = MutableStateFlow(30f)
         val swipeSensitivity = MutableStateFlow(1f)
         val preloadTargets = MutableStateFlow(emptyList<Int>())
 
-        every { adaptiveFlowManager.readingSpeedPagesPerMinute } returns readingSpeed
-        every { adaptiveFlowManager.swipeSensitivity } returns swipeSensitivity
-        every { adaptiveFlowManager.preloadTargets } returns preloadTargets
-        every { adaptiveFlowManager.start() } just runs
-        every { adaptiveFlowManager.stop() } just runs
-        every { adaptiveFlowManager.trackPageChange(any(), any()) } just runs
+        whenever(adaptiveFlowManager.readingSpeedPagesPerMinute).thenReturn(readingSpeed)
+        whenever(adaptiveFlowManager.swipeSensitivity).thenReturn(swipeSensitivity)
+        whenever(adaptiveFlowManager.preloadTargets).thenReturn(preloadTargets)
 
-        every { annotationRepository.annotationsForDocument(any()) } returns emptyList()
-        every { bookmarkManager.bookmarks(any()) } returns emptyList()
+        whenever(annotationRepository.annotationsForDocument(any())).thenReturn(emptyList())
+        whenever(bookmarkManager.bookmarks(any())).thenReturn(emptyList())
 
-        every { pdfRepository.preloadTiles(any(), any(), any()) } just runs
-
-        val renderer = mockk<PdfRenderer>()
-        val page = mockk<PdfRenderer.Page>()
-        every { page.width } returns 220
-        every { page.height } returns 400
-        every { page.close() } just runs
+        val renderer = mock<PdfRenderer>()
+        val page = mock<PdfRenderer.Page>()
+        whenever(page.width).thenReturn(220)
+        whenever(page.height).thenReturn(400)
 
         val glyphRuns = listOf(
             FakeGlyphRun("Lorem", Rect(0, 0, 100, 40)),
@@ -86,18 +80,18 @@ class PdfViewerViewModelSearchTest {
         )
         val textLine = FakeTextLine("Lorem ipsum", Rect(0, 0, 220, 40), glyphRuns)
 
-        every { page.getText() } returns listOf(textLine)
-        every { renderer.openPage(0) } returns page
+        whenever(page.getText()).thenReturn(listOf(textLine))
+        whenever(renderer.openPage(0)).thenReturn(page)
 
         val session = PdfDocumentSession(
             documentId = "doc",
             uri = Uri.parse("file://doc"),
             pageCount = 1,
             renderer = renderer,
-            fileDescriptor = mockk<ParcelFileDescriptor>()
+            fileDescriptor = mock<ParcelFileDescriptor>()
         )
         val sessionFlow = MutableStateFlow<PdfDocumentSession?>(session)
-        every { pdfRepository.session } returns sessionFlow
+        whenever(pdfRepository.session).thenReturn(sessionFlow)
 
         app.installDependencies(
             annotationRepository,
@@ -122,61 +116,56 @@ class PdfViewerViewModelSearchTest {
         assertTrue(second.left > 0.45f)
         assertTrue(second.right > 0.9f)
 
-        verify(exactly = 1) { page.getText() }
-        verify(exactly = 1) { page.close() }
+        verify(page).getText()
+        verify(page).close()
     }
 
     @Test
     @Config(sdk = [33], application = TestPdfApp::class)
     fun `performSearch falls back to bitmap detection below Api 34`() = runTest {
         val app = TestPdfApp.getInstance()
-        val annotationRepository = mockk<AnnotationRepository>()
-        val pdfRepository = mockk<PdfDocumentRepository>()
-        val adaptiveFlowManager = mockk<AdaptiveFlowManager>()
-        val bookmarkManager = mockk<BookmarkManager>()
-        val maintenanceScheduler = mockk<DocumentMaintenanceScheduler>(relaxed = true)
+        val annotationRepository = mock<AnnotationRepository>()
+        val pdfRepository = mock<PdfDocumentRepository>()
+        val adaptiveFlowManager = mock<AdaptiveFlowManager>()
+        val bookmarkManager = mock<BookmarkManager>()
+        val maintenanceScheduler = mock<DocumentMaintenanceScheduler>()
 
         val readingSpeed = MutableStateFlow(30f)
         val swipeSensitivity = MutableStateFlow(1f)
         val preloadTargets = MutableStateFlow(emptyList<Int>())
 
-        every { adaptiveFlowManager.readingSpeedPagesPerMinute } returns readingSpeed
-        every { adaptiveFlowManager.swipeSensitivity } returns swipeSensitivity
-        every { adaptiveFlowManager.preloadTargets } returns preloadTargets
-        every { adaptiveFlowManager.start() } just runs
-        every { adaptiveFlowManager.stop() } just runs
-        every { adaptiveFlowManager.trackPageChange(any(), any()) } just runs
+        whenever(adaptiveFlowManager.readingSpeedPagesPerMinute).thenReturn(readingSpeed)
+        whenever(adaptiveFlowManager.swipeSensitivity).thenReturn(swipeSensitivity)
+        whenever(adaptiveFlowManager.preloadTargets).thenReturn(preloadTargets)
 
-        every { annotationRepository.annotationsForDocument(any()) } returns emptyList()
-        every { bookmarkManager.bookmarks(any()) } returns emptyList()
+        whenever(annotationRepository.annotationsForDocument(any())).thenReturn(emptyList())
+        whenever(bookmarkManager.bookmarks(any())).thenReturn(emptyList())
 
-        every { pdfRepository.preloadTiles(any(), any(), any()) } just runs
+        val renderer = mock<PdfRenderer>()
+        val page = mock<PdfRenderer.Page>()
+        whenever(page.width).thenReturn(200)
+        whenever(page.height).thenReturn(200)
 
-        val renderer = mockk<PdfRenderer>()
-        val page = mockk<PdfRenderer.Page>()
-        every { page.width } returns 200
-        every { page.height } returns 200
-        every { page.close() } just runs
-
-        every { page.render(any(), any(), any(), any()) } answers {
-            val bitmap = arg<Bitmap>(0)
+        doAnswer {
+            val bitmap = it.getArgument<Bitmap>(0)
             val canvas = Canvas(bitmap)
             canvas.drawColor(Color.WHITE)
             val paint = Paint().apply { color = Color.BLACK }
             canvas.drawRect(Rect(10, 20, 90, 60), paint)
             canvas.drawRect(Rect(110, 120, 190, 160), paint)
-        }
-        every { renderer.openPage(0) } returns page
+            Unit
+        }.whenever(page).render(any(), any(), any(), any())
+        whenever(renderer.openPage(0)).thenReturn(page)
 
         val session = PdfDocumentSession(
             documentId = "doc",
             uri = Uri.parse("file://doc"),
             pageCount = 1,
             renderer = renderer,
-            fileDescriptor = mockk<ParcelFileDescriptor>()
+            fileDescriptor = mock<ParcelFileDescriptor>()
         )
         val sessionFlow = MutableStateFlow<PdfDocumentSession?>(session)
-        every { pdfRepository.session } returns sessionFlow
+        whenever(pdfRepository.session).thenReturn(sessionFlow)
 
         app.installDependencies(
             annotationRepository,
@@ -200,8 +189,8 @@ class PdfViewerViewModelSearchTest {
         assertTrue(first.left < first.right)
         assertTrue(second.left < second.right)
 
-        verify(exactly = 1) { page.render(any(), any(), any(), any()) }
-        verify(exactly = 1) { page.close() }
+        verify(page).render(any(), any(), any(), any())
+        verify(page).close()
     }
 
     class TestPdfApp : NovaPdfApp() {


### PR DESCRIPTION
## Summary
- replace MockK usage in `PdfViewerViewModelSearchTest` with Mockito mocks, stubs, and verifications
- update test dependencies to rely on Mockito (including inline support) instead of MockK

## Testing
- `./gradlew testDebugUnitTest` *(fails: Gradle wrapper download blocked by SSL handshake error in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4a0809f30832bbf79715d43d6180f