### PR TITLE
Add UI Automator instrumentation for adaptive flow and export

### DIFF
--- a/app/src/androidTest/kotlin/com/novapdf/reader/PdfViewerUiAutomatorTest.kt
+++ b/app/src/androidTest/kotlin/com/novapdf/reader/PdfViewerUiAutomatorTest.kt
@@ -1,0 +1,123 @@
+package com.novapdf.reader
+
+import android.content.Context
+import android.net.Uri
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.By
+import androidx.test.uiautomator.UiDevice
+import androidx.test.uiautomator.Until
+import androidx.work.WorkManager
+import com.novapdf.reader.work.DocumentMaintenanceWorker
+import java.util.concurrent.TimeUnit
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class PdfViewerUiAutomatorTest {
+
+    @get:Rule
+    val activityRule = ActivityScenarioRule(MainActivity::class.java)
+
+    private lateinit var device: UiDevice
+    private lateinit var appContext: Context
+    private lateinit var documentUri: Uri
+
+    @Before
+    fun setUp() = runBlocking {
+        device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+        appContext = ApplicationProvider.getApplicationContext()
+        documentUri = TestDocumentFixtures.installThousandPageDocument(appContext)
+        withContext(Dispatchers.IO) {
+            WorkManager.getInstance(appContext).cancelAllWork().result.get(5, TimeUnit.SECONDS)
+        }
+    }
+
+    @After
+    fun tearDown() {
+        runBlocking {
+            withContext(Dispatchers.IO) {
+                WorkManager.getInstance(appContext).cancelAllWork().result.get(5, TimeUnit.SECONDS)
+            }
+        }
+    }
+
+    @Test
+    fun loadsThousandPageDocumentAndActivatesAdaptiveFlow() = runBlocking {
+        openDocumentInViewer()
+
+        // Exercise paging by swiping left to move forward.
+        val startX = device.displayWidth * 3 / 4
+        val endX = device.displayWidth / 4
+        val centerY = device.displayHeight / 2
+        device.swipe(startX, centerY, endX, centerY, 40)
+        device.waitForIdle()
+
+        val app = ApplicationProvider.getApplicationContext<NovaPdfApp>()
+        app.adaptiveFlowManager.overrideSensitivityForTesting(1.6f)
+
+        val adaptiveFlowActive = device.wait(
+            Until.hasObject(By.textContains("Adaptive Flow Active")),
+            UI_WAIT_TIMEOUT
+        )
+        assertTrue(adaptiveFlowActive, "Adaptive Flow status chip should report Active")
+
+        activityRule.scenario.onActivity { activity ->
+            val state = activity.currentDocumentStateForTest()
+            assertEquals(1000, state.pageCount)
+        }
+    }
+
+    @Test
+    fun savingAnnotationsSchedulesImmediateWork() = runBlocking {
+        openDocumentInViewer()
+
+        val saveButton = device.wait(Until.findObject(By.desc("Save annotations")), UI_WAIT_TIMEOUT)
+        assertNotNull(saveButton, "Save annotations action should be visible")
+        saveButton.click()
+        device.waitForIdle()
+
+        val workInfos = withContext(Dispatchers.IO) {
+            WorkManager.getInstance(appContext)
+                .getWorkInfosForUniqueWork(DocumentMaintenanceWorker.IMMEDIATE_WORK_NAME)
+                .get(5, TimeUnit.SECONDS)
+        }
+        assertTrue(workInfos.isNotEmpty(), "Immediate autosave work should be enqueued")
+        val immediateWork = workInfos.first()
+        assertTrue(
+            immediateWork.tags.contains(DocumentMaintenanceWorker.TAG_IMMEDIATE),
+            "Immediate autosave work should include the expected tag"
+        )
+        val targetDocuments = assertNotNull(
+            immediateWork.inputData.getStringArray(DocumentMaintenanceWorker.KEY_DOCUMENT_IDS)
+        )
+        assertTrue(targetDocuments.isNotEmpty())
+    }
+
+    private fun openDocumentInViewer() {
+        activityRule.scenario.onActivity { activity ->
+            activity.openDocumentForTest(documentUri)
+        }
+        val statusVisible = device.wait(
+            Until.hasObject(By.textContains("Adaptive Flow")),
+            UI_WAIT_TIMEOUT
+        )
+        assertTrue(statusVisible, "Adaptive Flow status chip should appear after opening a document")
+        device.waitForIdle()
+    }
+
+    private companion object {
+        private const val UI_WAIT_TIMEOUT = 5_000L
+    }
+}

--- a/app/src/main/kotlin/com/novapdf/reader/AdaptiveFlowManager.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/AdaptiveFlowManager.kt
@@ -6,6 +6,7 @@ import android.hardware.SensorEvent
 import android.hardware.SensorEventListener
 import android.hardware.SensorManager
 import android.view.Choreographer
+import androidx.annotation.VisibleForTesting
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -145,6 +146,11 @@ class AdaptiveFlowManager(
     }
 
     override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) = Unit
+
+    @VisibleForTesting
+    internal fun overrideSensitivityForTesting(value: Float) {
+        _swipeSensitivity.value = value.coerceIn(0.6f, 2.5f)
+    }
 
     private fun startFrameMonitoring() {
         if (isFrameCallbackRegistered) return

--- a/app/src/main/kotlin/com/novapdf/reader/MainActivity.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/MainActivity.kt
@@ -15,6 +15,7 @@ import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.annotation.StringRes
+import androidx.annotation.VisibleForTesting
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
 import androidx.compose.ui.graphics.Color
@@ -209,6 +210,16 @@ class MainActivity : ComponentActivity() {
             }
             snackbar.show()
         }
+    }
+
+    @VisibleForTesting
+    internal fun openDocumentForTest(uri: Uri) {
+        viewModel.openDocument(uri)
+    }
+
+    @VisibleForTesting
+    internal fun currentDocumentStateForTest(): PdfViewerUiState {
+        return viewModel.uiState.value
     }
 
     private fun setupLegacyUi() {


### PR DESCRIPTION
## Summary
- add instrumentation fixtures that generate a thousand-page stress document for tests
- create UI Automator instrumentation tests exercising adaptive flow activation and annotation export flows
- expose testing hooks on AdaptiveFlowManager and MainActivity to drive scenarios from instrumentation

## Testing
- `./gradlew assembleAndroidTest` *(fails: unable to download Gradle distribution because of SSL handshake restrictions in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4a166ae94832b80658d2e62217aa6