### PR TITLE
Fix Gradle taskGraph configuration

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,6 +2,7 @@
 import com.android.build.api.dsl.ApplicationExtension
 import org.gradle.api.GradleException
 import org.gradle.api.Project
+import org.gradle.api.execution.TaskExecutionGraph
 import org.gradle.api.tasks.testing.Test
 import java.io.File
 
@@ -133,7 +134,7 @@ android {
 val androidExtension = extensions.getByType<ApplicationExtension>()
 val releaseSigningConfig = androidExtension.signingConfigs.getByName("release")
 
-gradle.taskGraph.whenReady { graph ->
+gradle.taskGraph.whenReady { graph: TaskExecutionGraph ->
     val needsReleaseSigning = graph.allTasks.any { task ->
         task.project == project && task.name.contains("Release")
     }


### PR DESCRIPTION
## Summary
- add the missing TaskExecutionGraph import for the release signing configuration
- specify the task graph parameter type to keep the Kotlin DSL lambda strongly typed

## Testing
- ./gradlew help *(fails: Gradle distribution download blocked by SSL certificate issue in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4a30bc408832b898cd1c83cccf3c1