### PR TITLE
Add manual trigger and concurrency guard to CI workflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,13 +1,19 @@
 name: Android CI/CD
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
   pull_request:
 
+concurrency:
+  group: android-ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build-test:
     runs-on: macos-latest
+    timeout-minutes: 360
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary
- allow manually running the Android CI/CD workflow
- ensure only a single workflow run executes per ref at a time
- define an explicit timeout for the macOS build job

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4a6cf54d0832bae9bbd2e373453a3