### PR TITLE
Fix Kotlin DSL taskGraph listener

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,9 +1,9 @@
 
 import com.android.build.api.dsl.ApplicationExtension
+import org.gradle.api.Action
 import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.tasks.testing.Test
-import org.gradle.kotlin.dsl.closureOf
 import java.io.File
 
 fun Project.resolveSigningCredential(name: String, default: String? = null): String =
@@ -136,8 +136,8 @@ val releaseSigningConfig = androidExtension.signingConfigs.getByName("release")
 
 val targetProject = project
 
-gradle.taskGraph.whenReady(closureOf {
-    val needsReleaseSigning = allTasks.any { task ->
+gradle.taskGraph.whenReady(Action { graph ->
+    val needsReleaseSigning = graph.allTasks.any { task ->
         task.project == targetProject && task.name.contains("Release")
     }
     if (needsReleaseSigning) {


### PR DESCRIPTION
## Summary
- replace Groovy closure usage in `gradle.taskGraph.whenReady` with a Kotlin `Action` so the Kotlin DSL script compiles
- remove the unused `closureOf` import in `app/build.gradle.kts`

## Testing
- `./gradlew assembleDebug` *(fails: SSLHandshakeException when fetching Gradle wrapper dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d4a84883ac832b95cf3e5139ee4a7c