### PR TITLE
Expand emulator matrix with ARM configurations

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -36,12 +36,24 @@ jobs:
             avd: pixelfold_api34
             tag: google_apis
             ram_mb: 6144
+          - api: 34
+            abi: arm64-v8a
+            device: pixel_6
+            avd: pixel6_api34
+            tag: google_apis
+            ram_mb: 6144
           - api: 35
             abi: x86_64
             device: pixel_7
             avd: pixel7_api35
             tag: google_apis
             ram_mb: 8192
+          - api: 30
+            abi: armeabi-v7a
+            device: "Nexus 10"
+            avd: nexus10_api30
+            tag: google_apis
+            ram_mb: 512
     env:
       GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g"
       ARTIFACTS_DIR: artifacts


### PR DESCRIPTION
## Summary
- extend the GitHub Actions emulator matrix with an arm64-v8a Pixel 6 profile
- add an armeabi-v7a Nexus 10 low-RAM tablet profile to cover 512 MB devices

## Testing
- Not run (configuration-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d4a9c453ac832b970a3e178baf73ec