### PR TITLE
Fix release signing configuration in Gradle script

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,5 @@
 
 import com.android.build.api.dsl.ApplicationExtension
-import org.gradle.api.Action
 import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.tasks.testing.Test
@@ -144,20 +143,20 @@ val releaseSigningConfig = androidExtension.signingConfigs.getByName("release")
 
 val targetProject = project
 
-gradle.taskGraph.whenReady(Action { graph ->
-    val needsReleaseSigning = graph.allTasks.any { task ->
+gradle.taskGraph.whenReady {
+    val needsReleaseSigning = allTasks.any { task ->
         task.project == targetProject && task.name.contains("Release")
     }
     if (needsReleaseSigning) {
         val releaseKeystore = targetProject.resolveReleaseKeystore()
         releaseSigningConfig.apply {
-            storeFile = releaseKeystore
-            storePassword = targetProject.resolveSigningCredential("NOVAPDF_RELEASE_STORE_PASSWORD")
-            keyAlias = targetProject.resolveSigningCredential("NOVAPDF_RELEASE_KEY_ALIAS")
-            keyPassword = targetProject.resolveSigningCredential("NOVAPDF_RELEASE_KEY_PASSWORD")
+            storeFile.set(releaseKeystore)
+            storePassword.set(targetProject.resolveSigningCredential("NOVAPDF_RELEASE_STORE_PASSWORD"))
+            keyAlias.set(targetProject.resolveSigningCredential("NOVAPDF_RELEASE_KEY_ALIAS"))
+            keyPassword.set(targetProject.resolveSigningCredential("NOVAPDF_RELEASE_KEY_PASSWORD"))
         }
     }
-})
+}
 
 dependencies {
     val composeBom = platform("androidx.compose:compose-bom:2024.06.00")


### PR DESCRIPTION
## Summary
- update the dynamic release signing configuration to use Kotlin DSL style lambdas
- switch signing config assignments to property setters compatible with AGP 8.5

## Testing
- ./gradlew help *(fails: unable to download Gradle distribution due to SSL handshake issues in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4ac82bc18832ba4242ae1f1cb4f24