### PR TITLE
Fix release signing config assignments

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -150,10 +150,10 @@ gradle.taskGraph.whenReady {
     if (needsReleaseSigning) {
         val releaseKeystore = targetProject.resolveReleaseKeystore()
         releaseSigningConfig.apply {
-            storeFile.set(releaseKeystore)
-            storePassword.set(targetProject.resolveSigningCredential("NOVAPDF_RELEASE_STORE_PASSWORD"))
-            keyAlias.set(targetProject.resolveSigningCredential("NOVAPDF_RELEASE_KEY_ALIAS"))
-            keyPassword.set(targetProject.resolveSigningCredential("NOVAPDF_RELEASE_KEY_PASSWORD"))
+            storeFile = releaseKeystore
+            storePassword = targetProject.resolveSigningCredential("NOVAPDF_RELEASE_STORE_PASSWORD")
+            keyAlias = targetProject.resolveSigningCredential("NOVAPDF_RELEASE_KEY_ALIAS")
+            keyPassword = targetProject.resolveSigningCredential("NOVAPDF_RELEASE_KEY_PASSWORD")
         }
     }
 }


### PR DESCRIPTION
## Summary
- assign release signing credentials using property setters compatible with AGP 8.5

## Testing
- ❌ `./gradlew help` *(fails: Gradle wrapper download blocked by SSL certificate issue in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d4b7b93e18832bbb828bc91a5f01ab