### PR TITLE
Fix baseline profile Gradle configuration

### DIFF
--- a/baselineprofile/build.gradle.kts
+++ b/baselineprofile/build.gradle.kts
@@ -1,4 +1,5 @@
 import com.android.build.api.dsl.TestExtension
+import org.gradle.api.execution.TaskExecutionGraph
 
 plugins {
     id("com.android.test")
@@ -23,7 +24,9 @@ android {
     }
 
     targetProjectPath = ":app"
-    testBuildType = "benchmark"
+    targetVariants {
+        onlyBuildType("benchmark")
+    }
     experimentalProperties["android.experimental.self-instrumenting"] = true
 }
 
@@ -62,7 +65,7 @@ tasks.register("startupBenchmark") {
     dependsOn("connectedBenchmarkAndroidTest")
 }
 
-gradle.taskGraph.whenReady { taskGraph ->
+gradle.taskGraph.whenReady { taskGraph: TaskExecutionGraph ->
     val arguments = testExtension.defaultConfig.testInstrumentationRunnerArguments
     when {
         taskGraph.hasTask(":baselineprofile:frameRateBenchmark") ->


### PR DESCRIPTION
## Summary
- update the baseline profile module to target the benchmark build type through the new targetVariants DSL
- import TaskExecutionGraph and use a typed lambda so task graph hooks compile under Kotlin DSL

## Testing
- `./gradlew :baselineprofile:tasks --no-daemon` *(fails: Gradle wrapper download blocked by SSL certificate issue in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4fe8d88f8832b95482f84648e7b99