### PR TITLE
Fix baseline profile build for AGP 8.5

### DIFF
--- a/baselineprofile/build.gradle.kts
+++ b/baselineprofile/build.gradle.kts
@@ -1,4 +1,5 @@
 import com.android.build.api.dsl.TestExtension
+import org.gradle.api.Action
 import org.gradle.api.execution.TaskExecutionGraph
 
 plugins {
@@ -24,9 +25,7 @@ android {
     }
 
     targetProjectPath = ":app"
-    targetVariants {
-        onlyBuildType("benchmark")
-    }
+    testBuildType = "benchmark"
     experimentalProperties["android.experimental.self-instrumenting"] = true
 }
 
@@ -65,7 +64,7 @@ tasks.register("startupBenchmark") {
     dependsOn("connectedBenchmarkAndroidTest")
 }
 
-gradle.taskGraph.whenReady { taskGraph: TaskExecutionGraph ->
+gradle.taskGraph.whenReady(Action<TaskExecutionGraph> { taskGraph ->
     val arguments = testExtension.defaultConfig.testInstrumentationRunnerArguments
     when {
         taskGraph.hasTask(":baselineprofile:frameRateBenchmark") ->
@@ -76,4 +75,4 @@ gradle.taskGraph.whenReady { taskGraph: TaskExecutionGraph ->
             arguments["annotation"] = "com.novapdf.reader.baselineprofile.annotations.StartupMetric"
         else -> arguments.remove("annotation")
     }
-}
+})


### PR DESCRIPTION
## Summary
- replace the removed `targetVariants` DSL with `testBuildType` to target the benchmark build type under AGP 8.5
- wrap the task graph listener with an explicit `Action` implementation so the Kotlin DSL script compiles
- add the required `Action` import

## Testing
- `./gradlew :baselineprofile:assemble` *(fails: Gradle wrapper download blocked by SSL handshake in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d500bf52d4832bbb3b291f24850b3f