### PR TITLE
Fix compilation errors from Gradle build

### DIFF
--- a/app/src/main/kotlin/com/novapdf/reader/AdaptiveFlowManager.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/AdaptiveFlowManager.kt
@@ -51,7 +51,7 @@ class AdaptiveFlowManager(
     private var lastFrameTimeNanos = 0L
     private val frameDurations = ArrayDeque<Float>()
 
-    private val frameCallback = Choreographer.FrameCallback { frameTimeNanos ->
+    private val frameCallback: Choreographer.FrameCallback = Choreographer.FrameCallback { frameTimeNanos ->
         val currentChoreographer = choreographer ?: return@FrameCallback
         if (lastFrameTimeNanos != 0L) {
             val deltaMillis = (frameTimeNanos - lastFrameTimeNanos) / 1_000_000f

--- a/app/src/main/kotlin/com/novapdf/reader/MainActivity.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/MainActivity.kt
@@ -18,6 +18,7 @@ import androidx.annotation.StringRes
 import androidx.annotation.VisibleForTesting
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.graphics.Color
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible

--- a/app/src/main/kotlin/com/novapdf/reader/PdfViewerScreen.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/PdfViewerScreen.kt
@@ -25,7 +25,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.fillParentMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListLayoutInfo
@@ -783,7 +782,7 @@ private fun PdfPager(
         userScrollEnabled = state.pageCount > 0
     ) {
         items(count = state.pageCount, key = { it }) { pageIndex ->
-            Box(modifier = Modifier.fillParentMaxSize()) {
+            Box(modifier = Modifier.fillMaxSize()) {
                 PdfPageContainer(
                     pageIndex = pageIndex,
                     state = state,

--- a/app/src/main/kotlin/com/novapdf/reader/PdfViewerViewModel.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/PdfViewerViewModel.kt
@@ -34,6 +34,8 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 import com.novapdf.reader.work.DocumentMaintenanceScheduler
 
+private const val DEFAULT_THEME_SEED_COLOR = 0xFFD32F2FL
+
 data class PdfViewerUiState(
     val documentId: String? = null,
     val pageCount: Int = 0,
@@ -403,7 +405,4 @@ class PdfViewerViewModel(
         return mask == Configuration.UI_MODE_NIGHT_YES
     }
 
-    companion object {
-        private const val DEFAULT_THEME_SEED_COLOR = 0xFFD32F2FL
-    }
 }

--- a/app/src/main/kotlin/com/novapdf/reader/data/PdfDocumentRepository.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/data/PdfDocumentRepository.kt
@@ -32,6 +32,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.coroutines.runBlocking
 import java.io.IOException
 import android.print.PageRange
+import android.print.PrintAttributes
 import android.print.PrintDocumentAdapter
 import android.print.PrintDocumentInfo
 import com.novapdf.reader.model.PdfOutlineNode

--- a/app/src/main/kotlin/com/novapdf/reader/legacy/LegacyPdfPageAdapter.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/legacy/LegacyPdfPageAdapter.kt
@@ -108,7 +108,7 @@ class LegacyPdfPageAdapter(
     }
 
     private suspend fun renderPageBitmap(pageIndex: Int): Bitmap? {
-        val size = viewModel.requestPageSize(pageIndex) ?: return null
+        val size = viewModel.pageSize(pageIndex) ?: return null
         val metrics = context.resources.displayMetrics
         val horizontalPadding = context.resources.getDimensionPixelSize(R.dimen.legacy_page_horizontal_margin) * 2
         val targetWidth = max(1, metrics.widthPixels - horizontalPadding)


### PR DESCRIPTION
## Summary
- annotate the adaptive frame callback to avoid recursive type inference
- import missing Compose and Android printing APIs, and correct Compose layout usage
- expose the default theme color constant and align legacy adapter with the available page sizing API

## Testing
- `./gradlew :app:compileDebugKotlin` *(fails: Gradle distribution download blocked by SSL handshake in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d52a9351c8832b8b8b8855c6badb4a