### PR TITLE
Fix compile errors in adaptive flow and pager animation

### DIFF
--- a/app/src/main/kotlin/com/novapdf/reader/AdaptiveFlowManager.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/AdaptiveFlowManager.kt
@@ -51,14 +51,16 @@ class AdaptiveFlowManager(
     private var lastFrameTimeNanos = 0L
     private val frameDurations = ArrayDeque<Float>()
 
-    private val frameCallback: Choreographer.FrameCallback = Choreographer.FrameCallback { frameTimeNanos ->
-        val currentChoreographer = choreographer ?: return@FrameCallback
-        if (lastFrameTimeNanos != 0L) {
-            val deltaMillis = (frameTimeNanos - lastFrameTimeNanos) / 1_000_000f
-            updateFrameMetrics(deltaMillis)
+    private val frameCallback = object : Choreographer.FrameCallback {
+        override fun doFrame(frameTimeNanos: Long) {
+            val currentChoreographer = choreographer ?: return
+            if (lastFrameTimeNanos != 0L) {
+                val deltaMillis = (frameTimeNanos - lastFrameTimeNanos) / 1_000_000f
+                updateFrameMetrics(deltaMillis)
+            }
+            lastFrameTimeNanos = frameTimeNanos
+            currentChoreographer.postFrameCallback(this)
         }
-        lastFrameTimeNanos = frameTimeNanos
-        currentChoreographer.postFrameCallback(frameCallback)
     }
 
     fun start() {

--- a/app/src/main/kotlin/com/novapdf/reader/PdfViewerScreen.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/PdfViewerScreen.kt
@@ -10,6 +10,7 @@ import android.view.GestureDetector
 import android.view.MotionEvent
 import android.view.ScaleGestureDetector
 import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.SpringSpec
 import androidx.compose.animation.core.spring
 import androidx.compose.animation.rememberSplineBasedDecay
 import androidx.compose.foundation.Canvas
@@ -736,7 +737,9 @@ private fun PdfPager(
     val latestRequestPageSize by rememberUpdatedState(requestPageSize)
     val latestTileSpecChanged by rememberUpdatedState(onTileSpecChanged)
     val decaySpec = rememberSplineBasedDecay<Float>()
-    val snapAnimationSpec = remember { spring(stiffness = Spring.StiffnessMediumLow, dampingRatio = 0.85f) }
+    val snapAnimationSpec: SpringSpec<Float> = remember {
+        spring(stiffness = Spring.StiffnessMediumLow, dampingRatio = 0.85f)
+    }
     val snapLayoutInfoProvider = remember(lazyListState) { PagerSnapLayoutInfoProvider(lazyListState) }
     val flingBehavior = remember(decaySpec, snapAnimationSpec, snapLayoutInfoProvider) {
         snapFlingBehavior(


### PR DESCRIPTION
## Summary
- convert the Choreographer frame callback in `AdaptiveFlowManager` to an object implementation so it can repost itself safely
- explicitly type the pager snap animation spring in `PdfViewerScreen` and add the missing import to satisfy Compose's type inference

## Testing
- ⚠️ `./gradlew :app:compileDebugKotlin` *(fails: Gradle wrapper download blocked by SSL handshake in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d53025ca2c832bae8d4e4073333f2b