### PR TITLE
Update Mockito inline dependency

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -203,7 +203,7 @@ dependencies {
 
     testImplementation("org.junit.jupiter:junit-jupiter:5.10.3")
     testImplementation("org.mockito.kotlin:mockito-kotlin:5.2.1")
-    testImplementation("org.mockito:mockito-inline:5.11.0")
+    testImplementation("org.mockito:mockito-inline:5.12.0")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.1")
     testImplementation("org.robolectric:robolectric:4.12.1")
     testImplementation("junit:junit:4.13.2")


### PR DESCRIPTION
## Summary
- bump the Mockito inline test dependency to version 5.12.0 so it resolves correctly from Maven Central

## Testing
- ⚠️ `./gradlew testDebugUnitTest` *(fails: Gradle wrapper download blocked by SSL certificate issue in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d53f39d70c832b824a989ceb6d1b20