### PR TITLE
Fix mockito inline dependency resolution failure

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -203,7 +203,7 @@ dependencies {
 
     testImplementation("org.junit.jupiter:junit-jupiter:5.10.3")
     testImplementation("org.mockito.kotlin:mockito-kotlin:5.2.1")
-    testImplementation("org.mockito:mockito-inline:5.12.0")
+    testImplementation("org.mockito:mockito-inline:5.11.0")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.1")
     testImplementation("org.robolectric:robolectric:4.12.1")
     testImplementation("junit:junit:4.13.2")


### PR DESCRIPTION
## Summary
- update the Mockito Inline test dependency to a version that is available on Maven Central to fix Gradle sync failures

## Testing
- ./gradlew testDebugUnitTest --stacktrace *(fails: Gradle wrapper download blocked by SSL handshake in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d54213a9d0832bbc02fcce469497ab