### PR TITLE
Fix mockito-inline dependency version

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -203,7 +203,7 @@ dependencies {
 
     testImplementation("org.junit.jupiter:junit-jupiter:5.10.3")
     testImplementation("org.mockito.kotlin:mockito-kotlin:5.2.1")
-    testImplementation("org.mockito:mockito-inline:5.11.0")
+    testImplementation("org.mockito:mockito-inline:5.2.0")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.1")
     testImplementation("org.robolectric:robolectric:4.12.1")
     testImplementation("junit:junit:4.13.2")


### PR DESCRIPTION
## Summary
- update the mockito-inline test dependency to the latest available version on Maven Central so the build can resolve it

## Testing
- ⚠️ `./gradlew testDebugUnitTest` *(fails: Gradle wrapper download blocked by SSL handshake in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d547075118832b8ade3631257e6f39