### PR TITLE
Fix unit tests and Room annotations

### DIFF
--- a/app/src/main/kotlin/com/novapdf/reader/NovaPdfApp.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/NovaPdfApp.kt
@@ -9,7 +9,7 @@ import com.novapdf.reader.data.NovaPdfDatabase
 import com.novapdf.reader.data.PdfDocumentRepository
 import com.novapdf.reader.work.DocumentMaintenanceScheduler
 
-class NovaPdfApp : Application() {
+open class NovaPdfApp : Application() {
     lateinit var annotationRepository: AnnotationRepository
         private set
     lateinit var pdfDocumentRepository: PdfDocumentRepository

--- a/app/src/main/kotlin/com/novapdf/reader/PdfViewerViewModel.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/PdfViewerViewModel.kt
@@ -67,7 +67,7 @@ private data class DocumentContext(
     val outline: List<PdfOutlineNode>
 )
 
-class PdfViewerViewModel(
+open class PdfViewerViewModel(
     application: Application
 ) : AndroidViewModel(application) {
     private val app = application as NovaPdfApp
@@ -291,7 +291,7 @@ class PdfViewerViewModel(
         }
     }
 
-    private fun extractTextRuns(page: PdfRenderer.Page): List<TextRunSnapshot> {
+    internal open fun extractTextRuns(page: PdfRenderer.Page): List<TextRunSnapshot> {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
             return emptyList()
         }

--- a/app/src/test/kotlin/com/novapdf/reader/data/BookmarkDaoTest.kt
+++ b/app/src/test/kotlin/com/novapdf/reader/data/BookmarkDaoTest.kt
@@ -5,22 +5,22 @@ import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertFalse
-import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
-import org.robolectric.junit5.RobolectricExtension
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
 @OptIn(ExperimentalCoroutinesApi::class)
-@ExtendWith(RobolectricExtension::class)
+@RunWith(RobolectricTestRunner::class)
 class BookmarkDaoTest {
     private lateinit var database: NovaPdfDatabase
     private lateinit var dao: BookmarkDao
 
-    @BeforeEach
+    @Before
     fun setUp() {
         val context = ApplicationProvider.getApplicationContext<Context>()
         database = Room.inMemoryDatabaseBuilder(context, NovaPdfDatabase::class.java)
@@ -29,7 +29,7 @@ class BookmarkDaoTest {
         dao = database.bookmarkDao()
     }
 
-    @AfterEach
+    @After
     fun tearDown() {
         database.close()
     }

--- a/app/src/test/kotlin/com/novapdf/reader/data/BookmarkManagerTest.kt
+++ b/app/src/test/kotlin/com/novapdf/reader/data/BookmarkManagerTest.kt
@@ -7,25 +7,25 @@ import androidx.test.core.app.ApplicationProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertFalse
-import org.junit.jupiter.api.Assertions.assertNull
-import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
-import org.robolectric.junit5.RobolectricExtension
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
 @OptIn(ExperimentalCoroutinesApi::class)
-@ExtendWith(RobolectricExtension::class)
+@RunWith(RobolectricTestRunner::class)
 class BookmarkManagerTest {
     private lateinit var context: Context
     private lateinit var database: NovaPdfDatabase
     private lateinit var dao: BookmarkDao
     private lateinit var preferences: SharedPreferences
 
-    @BeforeEach
+    @Before
     fun setUp() {
         context = ApplicationProvider.getApplicationContext()
         database = Room.inMemoryDatabaseBuilder(context, NovaPdfDatabase::class.java)
@@ -36,7 +36,7 @@ class BookmarkManagerTest {
         preferences.edit().clear().commit()
     }
 
-    @AfterEach
+    @After
     fun tearDown() {
         preferences.edit().clear().commit()
         database.close()

--- a/app/src/test/kotlin/com/novapdf/reader/ui/theme/DynamicColorSchemeTest.kt
+++ b/app/src/test/kotlin/com/novapdf/reader/ui/theme/DynamicColorSchemeTest.kt
@@ -3,7 +3,7 @@ package com.novapdf.reader.ui.theme
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.core.graphics.ColorUtils
-import kotlin.test.assertTrue
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class DynamicColorSchemeTest {

--- a/app/src/test/kotlin/com/novapdf/reader/work/DocumentMaintenanceWorkerTest.kt
+++ b/app/src/test/kotlin/com/novapdf/reader/work/DocumentMaintenanceWorkerTest.kt
@@ -43,7 +43,7 @@ class DocumentMaintenanceWorkerTest {
         val stroke = AnnotationCommand.Stroke(
             pageIndex = 0,
             points = listOf(PointSnapshot(0f, 0f), PointSnapshot(5f, 5f)),
-            color = 0xFF00FF00.toInt(),
+            color = 0xFF00FF00L,
             strokeWidth = 4f
         )
         app.annotationRepository.addAnnotation(documentId, stroke)


### PR DESCRIPTION
## Summary
- make `NovaPdfApp` extendable so Robolectric tests can override its setup
- allow `PdfViewerViewModel` to be subclassed in tests and override text extraction logic
- convert Bookmark DAO/manager tests to the Robolectric JUnit4 runner and clean up Mockito stubs
- stabilise dynamic colour and maintenance worker tests for Kotlin/JUnit expectations

## Testing
- `gradle testDebugUnitTest --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_68d54a97ce1c832b80e226484d00d4ec