### PR TITLE
Fix GitHub Actions avdmanager path

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -153,7 +153,7 @@ jobs:
           ABI: ${{ matrix.abi }}
         run: |
           set -euo pipefail
-          avdmanager create avd -n ${{ matrix.avd }} -k "system-images;android-${API_LEVEL};${{ matrix.tag }};${ABI}" --device "${{ matrix.device }}" --force
+          $ANDROID_HOME/cmdline-tools/latest/bin/avdmanager create avd -n ${{ matrix.avd }} -k "system-images;android-${API_LEVEL};${{ matrix.tag }};${ABI}" --device "${{ matrix.device }}" --force
           $ANDROID_HOME/emulator/emulator -avd ${{ matrix.avd }} -no-snapshot -no-window -gpu swiftshader_indirect -memory ${{ matrix.ram_mb }} -skin 1080x1920 -camera-back none -camera-front none -no-boot-anim &
           adb wait-for-device
           boot_timeout=0


### PR DESCRIPTION
## Summary
- ensure the Android emulator setup step invokes avdmanager via its absolute path in the GitHub Actions workflow to avoid command-not-found errors

## Testing
- not run (CI workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68d5671c81e4832bb894bd1b50c672fa