### PR TITLE
Fix Android CI system image selection for API 30

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -56,10 +56,10 @@ jobs:
           - api: 30
             device: "Nexus 10"
             avd: nexus10_api30
-            tag: google_apis
+            tag: default
             ram_mb: 512
-            x86_abi: armeabi-v7a
-            arm_abi: armeabi-v7a
+            x86_abi: x86
+            arm_abi: arm64-v8a
     env:
       GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g"
       ARTIFACTS_DIR: artifacts


### PR DESCRIPTION
## Summary
- update the API 30 matrix entry to use the default system image tag with valid ABIs so sdkmanager can download the package on macOS runners

## Testing
- not run (CI workflow only)

------
https://chatgpt.com/codex/tasks/task_e_68d61444cb5c832bbd016940881d8dbd