### PR TITLE
Fix baseline profile emulator directory lookup

### DIFF
--- a/baselineprofile/build.gradle.kts
+++ b/baselineprofile/build.gradle.kts
@@ -51,7 +51,9 @@ val verifyEmulatorAcceleration = tasks.register("verifyEmulatorAcceleration") {
     group = "verification"
     description = "Fails fast when required emulator acceleration is unavailable."
 
-    val emulatorDirectoryProvider = androidComponents.sdkComponents.emulatorDirectory
+    val emulatorDirectoryProvider = androidComponents.sdkComponents.sdkDirectory.map { sdkDir ->
+        sdkDir.dir("emulator")
+    }
 
     doLast {
         val emulatorDirectory = emulatorDirectoryProvider.get().asFile


### PR DESCRIPTION
## Summary
- update the baseline profile build script to derive the emulator directory from the SDK root so it works with AGP 8.5

## Testing
- not run (Gradle wrapper download failed because of SSL certificate issues in the environment)

------
https://chatgpt.com/codex/tasks/task_e_68d623f45bc0832b94dc81e150887a89