### PR TITLE
Fix baseline profile Gradle extension for AGP 8.5

### DIFF
--- a/baselineprofile/build.gradle.kts
+++ b/baselineprofile/build.gradle.kts
@@ -1,5 +1,5 @@
 import com.android.build.api.dsl.TestExtension
-import com.android.build.api.variant.AndroidComponentsExtension
+import com.android.build.api.variant.TestAndroidComponentsExtension
 import org.gradle.api.GradleException
 
 plugins {
@@ -45,7 +45,7 @@ dependencies {
 }
 
 val testExtension = extensions.getByType<TestExtension>()
-val androidComponents = extensions.getByType<AndroidComponentsExtension<*, *, *>>()
+val androidComponents = extensions.getByType<TestAndroidComponentsExtension>()
 
 val verifyEmulatorAcceleration = tasks.register("verifyEmulatorAcceleration") {
     group = "verification"


### PR DESCRIPTION
## Summary
- switch the baseline profile module to use TestAndroidComponentsExtension so the build can configure the SDK components when using AGP 8.5

## Testing
- `./gradlew :baselineprofile:tasks --no-daemon` *(fails: Gradle wrapper could not download due to SSL certificate validation error in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d696f1b534832b9f3ee95a30703530