### PR TITLE
Use fail-fast coroutine scopes

### DIFF
--- a/app/src/main/kotlin/com/novapdf/reader/AdaptiveFlowManager.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/AdaptiveFlowManager.kt
@@ -9,7 +9,7 @@ import android.view.Choreographer
 import androidx.annotation.VisibleForTesting
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -26,7 +26,7 @@ private const val DEFAULT_FRAME_INTERVAL_MS = 16.6f
 class AdaptiveFlowManager(
     context: Context,
     private val wallClock: () -> Long = System::currentTimeMillis,
-    private val coroutineScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private val coroutineScope: CoroutineScope = CoroutineScope(Job() + Dispatchers.Default)
 ) : SensorEventListener {
     private val sensorManager = context.getSystemService(Context.SENSOR_SERVICE) as SensorManager
     private val accelerometer: Sensor? = sensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER)

--- a/app/src/main/kotlin/com/novapdf/reader/data/PdfDocumentRepository.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/data/PdfDocumentRepository.kt
@@ -20,7 +20,7 @@ import androidx.core.graphics.createBitmap
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -71,7 +71,7 @@ class PdfDocumentRepository(
 ) {
     private val appContext: Context = context.applicationContext
     private val contentResolver: ContentResolver = context.contentResolver
-    private val renderScope = CoroutineScope(SupervisorJob() + ioDispatcher)
+    private val renderScope = CoroutineScope(Job() + ioDispatcher)
     private val cacheLock = Mutex()
     private val maxCacheBytes = calculateCacheBudget()
     private val bitmapCache = AccessOrderBitmapCache(maxCacheBytes)

--- a/app/src/test/kotlin/com/novapdf/reader/AdaptiveFlowManagerTest.kt
+++ b/app/src/test/kotlin/com/novapdf/reader/AdaptiveFlowManagerTest.kt
@@ -7,7 +7,7 @@ import android.hardware.SensorManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
@@ -104,7 +104,7 @@ class AdaptiveFlowManagerTest {
         val manager = AdaptiveFlowManager(
             context = context,
             wallClock = { 0L },
-            coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+            coroutineScope = CoroutineScope(Job() + Dispatchers.Default)
         )
 
         repeat(5) { manager.updateFrameMetrics(16f) }


### PR DESCRIPTION
## Summary
- replace SupervisorJob-based scopes in AdaptiveFlowManager and PdfDocumentRepository with Job to ensure failures cancel the whole scope
- update unit tests to match the new fail-fast coroutine scope configuration

## Testing
- ./gradlew test *(fails: SSL handshake when downloading Gradle distribution)*

------
https://chatgpt.com/codex/tasks/task_e_68d69c6947cc832ba5c8e9cec377ded4