### PR TITLE
Handle emulator acceleration fallback in CI

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -171,7 +171,13 @@ jobs:
         run: |
           set -euo pipefail
           $ANDROID_HOME/cmdline-tools/latest/bin/avdmanager create avd -n ${{ matrix.avd }} -k "system-images;android-${API_LEVEL};${{ matrix.tag }};${ABI}" --device "${{ matrix.device }}" --force
-          $ANDROID_HOME/emulator/emulator -avd ${{ matrix.avd }} -no-snapshot -no-window -gpu swiftshader_indirect -memory ${{ matrix.ram_mb }} -skin 1080x1920 -camera-back none -camera-front none -no-boot-anim &
+          accel_flag=""
+          if ! "$ANDROID_HOME"/emulator/emulator-check accel >/dev/null 2>&1; then
+            echo "Hardware acceleration unavailable; starting emulator with -accel off"
+            accel_flag="-accel off"
+          fi
+
+          $ANDROID_HOME/emulator/emulator -avd ${{ matrix.avd }} -no-snapshot -no-window -gpu swiftshader_indirect -memory ${{ matrix.ram_mb }} -skin 1080x1920 -camera-back none -camera-front none -no-boot-anim $accel_flag &
           emulator_pid=$!
 
           device_timeout=0


### PR DESCRIPTION
## Summary
- detect whether hardware acceleration is available before launching the Android emulator
- fall back to starting the emulator with `-accel off` when acceleration is unavailable to avoid HVF startup failures

## Testing
- not run (CI only)


------
https://chatgpt.com/codex/tasks/task_e_68d6b2a31c48832b94b6cc13e3bbe696