### PR TITLE
Disable Android emulator acceleration on macOS CI runners

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -168,11 +168,15 @@ jobs:
         env:
           API_LEVEL: ${{ matrix.api }}
           ABI: ${{ steps.select-abi.outputs.abi }}
+          RUNNER_OS: ${{ runner.os }}
         run: |
           set -euo pipefail
           $ANDROID_HOME/cmdline-tools/latest/bin/avdmanager create avd -n ${{ matrix.avd }} -k "system-images;android-${API_LEVEL};${{ matrix.tag }};${ABI}" --device "${{ matrix.device }}" --force
           accel_flag=""
-          if ! "$ANDROID_HOME"/emulator/emulator-check accel >/dev/null 2>&1; then
+          if [ "${RUNNER_OS:-}" = "macOS" ]; then
+            echo "macOS runners do not expose HVF; starting emulator with -accel off"
+            accel_flag="-accel off"
+          elif ! "$ANDROID_HOME"/emulator/emulator-check accel >/dev/null 2>&1; then
             echo "Hardware acceleration unavailable; starting emulator with -accel off"
             accel_flag="-accel off"
           fi


### PR DESCRIPTION
## Summary
- disable hardware acceleration for the Android emulator when running on macOS GitHub-hosted runners to avoid HVF failures
- expose the runner operating system to the start-emulator script for logging

## Testing
- not run (CI workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d6bb20eccc832b99cb04d1df0eb48a