### PR TITLE
Fix macOS CI emulator acceleration flag

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -174,11 +174,11 @@ jobs:
           $ANDROID_HOME/cmdline-tools/latest/bin/avdmanager create avd -n ${{ matrix.avd }} -k "system-images;android-${API_LEVEL};${{ matrix.tag }};${ABI}" --device "${{ matrix.device }}" --force
           accel_flag=""
           if [ "${RUNNER_OS:-}" = "macOS" ]; then
-            echo "macOS runners do not expose HVF; starting emulator with -accel off"
-            accel_flag="-accel off"
+            echo "macOS runners do not expose HVF; starting emulator with -no-accel"
+            accel_flag="-no-accel"
           elif ! "$ANDROID_HOME"/emulator/emulator-check accel >/dev/null 2>&1; then
-            echo "Hardware acceleration unavailable; starting emulator with -accel off"
-            accel_flag="-accel off"
+            echo "Hardware acceleration unavailable; starting emulator with -no-accel"
+            accel_flag="-no-accel"
           fi
 
           $ANDROID_HOME/emulator/emulator -avd ${{ matrix.avd }} -no-snapshot -no-window -gpu swiftshader_indirect -memory ${{ matrix.ram_mb }} -skin 1080x1920 -camera-back none -camera-front none -no-boot-anim $accel_flag &


### PR DESCRIPTION
## Summary
- switch the macOS emulator fallback to use -no-accel so HVF is not requested when unavailable

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6c0ac6ccc832b84e820d9b20a6a56