### PR TITLE
Fix hardware override append command in CI workflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -221,9 +221,7 @@ jobs:
           config_path="$HOME/.android/avd/${{ matrix.avd }}.avd/config.ini"
           if [ -n "${{ matrix.hardware_overrides }}" ]; then
             echo "Applying hardware overrides for ${{ matrix.device_label }}"
-            cat <<'EOF' >> "$config_path"
-${{ matrix.hardware_overrides }}
-EOF
+            printf '%s\n' "${{ matrix.hardware_overrides }}" >> "$config_path"
           fi
 
           accel_args=()


### PR DESCRIPTION
## Summary
- replace the heredoc append in the emulator setup with a printf to avoid invalid YAML indentation

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d6c94aeb8c832b9559e6c86a09a155