### PR TITLE
Avoid interactive avdmanager prompts in CI emulator setup

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -217,9 +217,9 @@ jobs:
             fi
           fi
 
-          if ! "${create_cmd[@]}"; then
+          if ! printf 'no\n' | "${create_cmd[@]}"; then
             echo "Falling back to default hardware profile for ${{ matrix.avd }}"
-            "$ANDROID_HOME/cmdline-tools/latest/bin/avdmanager" create avd -n ${{ matrix.avd }} -k "system-images;android-${API_LEVEL};${{ matrix.tag }};${ABI}" --force
+            printf 'no\n' | "$ANDROID_HOME/cmdline-tools/latest/bin/avdmanager" create avd -n ${{ matrix.avd }} -k "system-images;android-${API_LEVEL};${{ matrix.tag }};${ABI}" --force
           fi
 
           config_path="$HOME/.android/avd/${{ matrix.avd }}.avd/config.ini"


### PR DESCRIPTION
## Summary
- pipe a default "no" response into avdmanager create commands so they can run non-interactively during CI emulator setup

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68d73eb6674c832bb8c126fb4bee7552