### PR TITLE
Fix AVD config lookup in CI workflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -222,9 +222,27 @@ jobs:
             printf 'no\n' | "$ANDROID_HOME/cmdline-tools/latest/bin/avdmanager" create avd -n ${{ matrix.avd }} -k "system-images;android-${API_LEVEL};${{ matrix.tag }};${ABI}" --force
           fi
 
-          config_path="$HOME/.android/avd/${{ matrix.avd }}.avd/config.ini"
-          if [ ! -f "$config_path" ]; then
-            echo "AVD configuration not found at $config_path" >&2
+          sdk_home="${ANDROID_SDK_HOME:-$HOME}"
+          config_candidates=()
+          if [ -n "${ANDROID_AVD_HOME:-}" ]; then
+            config_candidates+=("${ANDROID_AVD_HOME%/}/${{ matrix.avd }}.avd/config.ini")
+          fi
+          config_candidates+=("${sdk_home%/}/.android/avd/${{ matrix.avd }}.avd/config.ini")
+          if [ "$sdk_home" != "$HOME" ]; then
+            config_candidates+=("$HOME/.android/avd/${{ matrix.avd }}.avd/config.ini")
+          fi
+
+          config_path=""
+          for candidate in "${config_candidates[@]}"; do
+            if [ -f "$candidate" ]; then
+              config_path="$candidate"
+              break
+            fi
+          done
+
+          if [ -z "$config_path" ]; then
+            echo "AVD configuration not found. Checked:" >&2
+            printf '  - %s\n' "${config_candidates[@]}" >&2
             exit 1
           fi
           if [ -n "${{ matrix.hardware_overrides }}" ]; then


### PR DESCRIPTION
## Summary
- search common Android SDK home directories when locating the generated AVD config file
- log all candidate config paths when the file cannot be found

## Testing
- not run (CI workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68d74922c4c4832bb5c3107306ae56aa