### PR TITLE
Handle delayed AVD config creation

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -233,15 +233,21 @@ jobs:
           fi
 
           config_path=""
-          for candidate in "${config_candidates[@]}"; do
-            if [ -f "$candidate" ]; then
-              config_path="$candidate"
-              break
-            fi
+          for attempt in $(seq 1 10); do
+            for candidate in "${config_candidates[@]}"; do
+              if [ -f "$candidate" ]; then
+                config_path="$candidate"
+                break 2
+              fi
+            done
+
+            # avdmanager occasionally finishes before the config file is flushed to disk
+            # which causes flaky failures on CI runners. Wait a moment and retry.
+            sleep 2
           done
 
           if [ -z "$config_path" ]; then
-            echo "AVD configuration not found. Checked:" >&2
+            echo "AVD configuration not found after waiting 20 seconds. Checked:" >&2
             printf '  - %s\n' "${config_candidates[@]}" >&2
             exit 1
           fi


### PR DESCRIPTION
## Summary
- wait for the generated AVD config.ini file to appear before applying hardware overrides
- retry detection for up to 20 seconds to avoid flaky emulator start failures in CI

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d74ba20218832b884f864b16cbc713