### PR TITLE
Increase AVD config wait time

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -233,7 +233,7 @@ jobs:
           fi
 
           config_path=""
-          for attempt in $(seq 1 10); do
+          for attempt in $(seq 1 30); do
             for candidate in "${config_candidates[@]}"; do
               if [ -f "$candidate" ]; then
                 config_path="$candidate"
@@ -247,7 +247,7 @@ jobs:
           done
 
           if [ -z "$config_path" ]; then
-            echo "AVD configuration not found after waiting 20 seconds. Checked:" >&2
+            echo "AVD configuration not found after waiting 60 seconds. Checked:" >&2
             printf '  - %s\n' "${config_candidates[@]}" >&2
             exit 1
           fi


### PR DESCRIPTION
## Summary
- extend the emulator config polling loop to allow up to 60 seconds for avdmanager to flush files
- update the corresponding log message to reflect the longer wait

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68d74d5eb54c832ba89b8c50954a150f