### PR TITLE
Extend AVD config wait for tablet emulator

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -238,7 +238,7 @@ jobs:
           fi
 
           config_path=""
-          for attempt in $(seq 1 30); do
+          for attempt in $(seq 1 90); do
             for candidate in "${config_candidates[@]}"; do
               if [ -f "$candidate" ]; then
                 config_path="$candidate"
@@ -252,7 +252,7 @@ jobs:
           done
 
           if [ -z "$config_path" ]; then
-            echo "AVD configuration not found after waiting 60 seconds. Checked:" >&2
+            echo "AVD configuration not found after waiting 180 seconds. Checked:" >&2
             printf '  - %s\n' "${config_candidates[@]}" >&2
             exit 1
           fi


### PR DESCRIPTION
## Summary
- extend the retry window when waiting for the emulator config.ini to appear so large AVDs have time to finish writing
- update the corresponding timeout message to reflect the longer wait period

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7560a3070832b8ce92dbe48addd2b