### PR TITLE
Improve emulator readiness detection in CI

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -300,7 +300,10 @@ jobs:
               exit 1
             fi
 
-            if adb devices | awk 'NR>1 && $2 == "device" { exit 0 } END { exit 1 }'; then
+            if adb devices |
+              tail -n +2 |
+              tr -d '\r' |
+              grep -qE '\sdevice$'; then
               break
             fi
 


### PR DESCRIPTION
## Summary
- make the emulator readiness check tolerate carriage returns in `adb devices` output so the workflow recognises the booted device

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d76c4d5060832bb4d94cb1068b69fa