### PR TITLE
Fix androidTest compilation issues

### DIFF
--- a/app/src/androidTest/kotlin/com/novapdf/reader/PdfViewerScreenTest.kt
+++ b/app/src/androidTest/kotlin/com/novapdf/reader/PdfViewerScreenTest.kt
@@ -32,6 +32,8 @@ class PdfViewerScreenTest {
                     onSaveAnnotations = {},
                     onSearch = {},
                     onToggleBookmark = {},
+                    onOutlineDestinationSelected = {},
+                    onExportDocument = { true },
                     renderTile = { _, _, _ -> null },
                     requestPageSize = { null },
                     onTileSpecChanged = {},

--- a/app/src/androidTest/kotlin/com/novapdf/reader/PdfViewerUiAutomatorTest.kt
+++ b/app/src/androidTest/kotlin/com/novapdf/reader/PdfViewerUiAutomatorTest.kt
@@ -12,9 +12,9 @@ import androidx.test.uiautomator.Until
 import androidx.work.WorkManager
 import com.novapdf.reader.work.DocumentMaintenanceWorker
 import java.util.concurrent.TimeUnit
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertTrue
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext


### PR DESCRIPTION
## Summary
- provide the new PdfViewerScreen callbacks in the empty state test to match the production signature
- switch instrumentation assertions to org.junit.Assert so the Android test sources compile

## Testing
- ./gradlew compileDebugAndroidTestKotlin *(fails: Gradle wrapper download blocked by SSL handshake error in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d785bfdee8832bb08ebc14f3ecb5c3