### PR TITLE
Fix assertion argument order in UI Automator tests

### DIFF
--- a/app/src/androidTest/kotlin/com/novapdf/reader/PdfViewerUiAutomatorTest.kt
+++ b/app/src/androidTest/kotlin/com/novapdf/reader/PdfViewerUiAutomatorTest.kt
@@ -71,7 +71,10 @@ class PdfViewerUiAutomatorTest {
             Until.hasObject(By.textContains("Adaptive Flow Active")),
             UI_WAIT_TIMEOUT
         )
-        assertTrue(adaptiveFlowActive, "Adaptive Flow status chip should report Active")
+        assertTrue(
+            "Adaptive Flow status chip should report Active",
+            adaptiveFlowActive
+        )
 
         activityRule.scenario.onActivity { activity ->
             val state = activity.currentDocumentStateForTest()
@@ -84,7 +87,7 @@ class PdfViewerUiAutomatorTest {
         openDocumentInViewer()
 
         val saveButton = device.wait(Until.findObject(By.desc("Save annotations")), UI_WAIT_TIMEOUT)
-        assertNotNull(saveButton, "Save annotations action should be visible")
+        assertNotNull("Save annotations action should be visible", saveButton)
         saveButton.click()
         device.waitForIdle()
 
@@ -93,16 +96,24 @@ class PdfViewerUiAutomatorTest {
                 .getWorkInfosForUniqueWork(DocumentMaintenanceWorker.IMMEDIATE_WORK_NAME)
                 .get(5, TimeUnit.SECONDS)
         }
-        assertTrue(workInfos.isNotEmpty(), "Immediate autosave work should be enqueued")
+        assertTrue(
+            "Immediate autosave work should be enqueued",
+            workInfos.isNotEmpty()
+        )
         val immediateWork = workInfos.first()
         assertTrue(
-            immediateWork.tags.contains(DocumentMaintenanceWorker.TAG_IMMEDIATE),
-            "Immediate autosave work should include the expected tag"
+            "Immediate autosave work should include the expected tag",
+            immediateWork.tags.contains(DocumentMaintenanceWorker.TAG_IMMEDIATE)
         )
-        val targetDocuments = assertNotNull(
+        val targetDocuments = requireNotNull(
             immediateWork.inputData.getStringArray(DocumentMaintenanceWorker.KEY_DOCUMENT_IDS)
+        ) {
+            "Immediate autosave work should include the document id payload"
+        }
+        assertTrue(
+            "Immediate autosave work should target at least one document",
+            targetDocuments.isNotEmpty()
         )
-        assertTrue(targetDocuments.isNotEmpty())
     }
 
     private fun openDocumentInViewer() {
@@ -113,7 +124,10 @@ class PdfViewerUiAutomatorTest {
             Until.hasObject(By.textContains("Adaptive Flow")),
             UI_WAIT_TIMEOUT
         )
-        assertTrue(statusVisible, "Adaptive Flow status chip should appear after opening a document")
+        assertTrue(
+            "Adaptive Flow status chip should appear after opening a document",
+            statusVisible
+        )
         device.waitForIdle()
     }
 


### PR DESCRIPTION
## Summary
- correct the JUnit assertion argument order used in PdfViewerUiAutomatorTest
- require non-null document id payloads before asserting their contents

## Testing
- ⚠️ `./gradlew :app:compileDebugAndroidTestKotlin` *(fails: Gradle wrapper download blocked by SSL handshake error)*

------
https://chatgpt.com/codex/tasks/task_e_68d78ba1ab58832baba535ed43bf38bd