### PR TITLE
Fix PdfViewerUiAutomatorTest WorkInfo assertion

### DIFF
--- a/app/src/androidTest/kotlin/com/novapdf/reader/PdfViewerUiAutomatorTest.kt
+++ b/app/src/androidTest/kotlin/com/novapdf/reader/PdfViewerUiAutomatorTest.kt
@@ -105,15 +105,6 @@ class PdfViewerUiAutomatorTest {
             "Immediate autosave work should include the expected tag",
             immediateWork.tags.contains(DocumentMaintenanceWorker.TAG_IMMEDIATE)
         )
-        val targetDocuments = requireNotNull(
-            immediateWork.inputData.getStringArray(DocumentMaintenanceWorker.KEY_DOCUMENT_IDS)
-        ) {
-            "Immediate autosave work should include the document id payload"
-        }
-        assertTrue(
-            "Immediate autosave work should target at least one document",
-            targetDocuments.isNotEmpty()
-        )
     }
 
     private fun openDocumentInViewer() {


### PR DESCRIPTION
## Summary
- remove the invalid WorkInfo inputData assertion from PdfViewerUiAutomatorTest
- keep the check that immediate work is enqueued with the expected tag

## Testing
- not run (instrumented tests require an Android device/emulator)


------
https://chatgpt.com/codex/tasks/task_e_68d7915bc5d4832ba9df9caad9e83b7c