### PR TITLE
Remove MANAGE_EXTERNAL_STORAGE from debug builds

### DIFF
--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <!-- Remove storage manager permission from debug builds to avoid installation failures on test devices. -->
+    <uses-permission
+        android:name="android.permission.MANAGE_EXTERNAL_STORAGE"
+        tools:node="remove" />
+</manifest>


### PR DESCRIPTION
## Summary
- remove the MANAGE_EXTERNAL_STORAGE permission from the debug manifest so test builds install without restricted storage access

## Testing
- ./gradlew connectedAndroidTest --stacktrace *(fails: SSL handshake error while downloading Gradle distribution)*

------
https://chatgpt.com/codex/tasks/task_e_68d79ae066b0832b9fe3678ce2f27b63