### PR TITLE
Use orchestrator to stabilize connected Android tests

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -137,6 +137,11 @@ android {
             it.useJUnitPlatform()
         }
         animationsDisabled = false
+        execution = "ANDROIDX_TEST_ORCHESTRATOR"
+    }
+
+    adbOptions {
+        installOptions.addAll(listOf("-t", "--no-streaming"))
     }
 
     lint {
@@ -251,6 +256,7 @@ dependencies {
     androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")
     androidTestImplementation("androidx.test.uiautomator:uiautomator:2.3.0")
     androidTestImplementation("androidx.compose.ui:ui-test-junit4")
+    androidTestUtil("androidx.test:orchestrator:1.4.2")
     debugImplementation("androidx.compose.ui:ui-tooling")
     debugImplementation("androidx.compose.ui:ui-test-manifest")
     baselineProfile(project(":baselineprofile"))


### PR DESCRIPTION
## Summary
- run connected instrumentation tests through the AndroidX Test Orchestrator to avoid unified test platform install issues
- disable streaming installs during adb operations so APK deployment succeeds reliably on emulators

## Testing
- not run (local environment Gradle wrapper download failed due to SSL handshake issues)


------
https://chatgpt.com/codex/tasks/task_e_68d7a2354a18832bbced32501b8c1c53