### PR TITLE
Make adb no-streaming flag opt-in

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -141,7 +141,17 @@ android {
     }
 
     adbOptions {
-        installOptions.addAll(listOf("-t", "--no-streaming"))
+        installOptions.add("-t")
+
+        val enableNoStreaming = (
+            (findProperty("novapdf.enableNoStreamingInstallOption") as? String)
+                ?: System.getenv("NOVAPDF_ENABLE_NO_STREAMING")
+            )?.equals("true", ignoreCase = true) ?: false
+
+        if (enableNoStreaming) {
+            // Allow opting back into the no-streaming flag for environments that support it.
+            installOptions.add("--no-streaming")
+        }
     }
 
     lint {


### PR DESCRIPTION
## Summary
- add a guard around the `--no-streaming` adb install option so that it is only enabled when explicitly requested

## Testing
- ./gradlew connectedAndroidTest --stacktrace *(fails: Gradle could not resolve the Android Gradle Plugin through the proxy environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7a8e2b420832bb0781d71ce58d290