### PR TITLE
Handle proxied environments for Gradle wrapper downloads

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://github.com/gradle/gradle-distributions/releases/download/v8.7.0/gradle-8.7-bin.zip
+distributionSha256Sum=544c35d6bd849ae8a5ed0bcea39ba677dc40f49df7d1835561582da2009b961d
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary
- Point the wrapper to the GitHub-hosted Gradle distribution and record its checksum so downloads succeed when the standard CDN is MITM’d.
- Teach the wrapper script to pre-download and verify the distribution, reuse the installed binary, and respect an optional CODEX proxy certificate by building a custom trust store.
- Allow opting out of the new path with `NOVAPDF_FORCE_WRAPPER_JAR` while keeping the existing wrapper JAR fallback logic intact.

## Testing
- `./gradlew --version`
- `./gradlew connectedDebugAndroidTest --stacktrace --console=plain` *(fails: Android SDK not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7b21ccbc8832bb7c127f9bc775727