### PR TITLE
Default to no-streaming installs on CI

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -145,13 +145,17 @@ android {
     adbOptions {
         installOptions.add("-t")
 
-        val enableNoStreaming = (
+        val explicitNoStreaming = parseOptionalBoolean(
             (findProperty("novapdf.enableNoStreamingInstallOption") as? String)
                 ?: System.getenv("NOVAPDF_ENABLE_NO_STREAMING")
-            )?.equals("true", ignoreCase = true) ?: false
+        )
+        val enableNoStreaming = explicitNoStreaming
+            ?: parseOptionalBoolean(System.getenv("CI"))
+            ?: false
 
         if (enableNoStreaming) {
-            // Allow opting back into the no-streaming flag for environments that support it.
+            // Disable streaming installs on CI by default because some hosted emulators
+            // intermittently fail session commits unless the legacy path is used.
             installOptions.add("--no-streaming")
         }
     }


### PR DESCRIPTION
## Summary
- default the Gradle ADB install options to include --no-streaming when running in CI unless explicitly overridden
- continue supporting manual control via the novapdf.enableNoStreamingInstallOption property or NOVAPDF_ENABLE_NO_STREAMING env var

## Testing
- `./gradlew --console=plain testDebugUnitTest` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d7c5e4c528832ba70b8df6488d2634