### PR TITLE
Disable default ADB no-streaming option on CI

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -149,12 +149,10 @@ android {
             (findProperty("novapdf.enableNoStreamingInstallOption") as? String)
                 ?: System.getenv("NOVAPDF_ENABLE_NO_STREAMING")
         )
-        val enableNoStreaming = explicitNoStreaming
-            ?: parseOptionalBoolean(System.getenv("CI"))
-            ?: false
+        val enableNoStreaming = explicitNoStreaming ?: false
 
         if (enableNoStreaming) {
-            // Disable streaming installs on CI by default because some hosted emulators
+            // Allow opting into legacy installs because some hosted emulators
             // intermittently fail session commits unless the legacy path is used.
             installOptions.add("--no-streaming")
         }


### PR DESCRIPTION
## Summary
- stop enabling the `--no-streaming` adb install option by default
- keep the option configurable when explicitly requested to support problematic emulators

## Testing
- not run (emulator setup unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d7cebd1708832b8b29e7a66b636b48