### PR TITLE
Fix baseline profile compilation errors

### DIFF
--- a/baselineprofile/src/main/java/com/novapdf/reader/baselineprofile/BaselineProfileGenerator.kt
+++ b/baselineprofile/src/main/java/com/novapdf/reader/baselineprofile/BaselineProfileGenerator.kt
@@ -1,6 +1,5 @@
 package com.novapdf.reader.baselineprofile
 
-import androidx.benchmark.macro.ExperimentalBaselineProfilesApi
 import androidx.benchmark.macro.junit4.BaselineProfileRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
@@ -15,16 +14,11 @@ class BaselineProfileGenerator {
     @get:Rule
     val baselineProfileRule = BaselineProfileRule()
 
-    @OptIn(ExperimentalBaselineProfilesApi::class)
     @Test
-    fun generate() = baselineProfileRule.collectBaselineProfile(
+    fun generate() = baselineProfileRule.collect(
         packageName = TARGET_PACKAGE
     ) {
         startActivityAndWait()
         device.waitForIdle()
-    }
-
-    private companion object {
-        const val TARGET_PACKAGE = "com.novapdf.reader"
     }
 }

--- a/baselineprofile/src/main/java/com/novapdf/reader/baselineprofile/MemoryBenchmark.kt
+++ b/baselineprofile/src/main/java/com/novapdf/reader/baselineprofile/MemoryBenchmark.kt
@@ -1,5 +1,6 @@
 package com.novapdf.reader.baselineprofile
 
+import androidx.benchmark.macro.ExperimentalMetricApi
 import androidx.benchmark.macro.MemoryUsageMetric
 import androidx.benchmark.macro.StartupMode
 import androidx.benchmark.macro.junit4.MacrobenchmarkRule
@@ -18,9 +19,10 @@ class MemoryBenchmark {
 
     @MemoryMetric
     @Test
+    @OptIn(ExperimentalMetricApi::class)
     fun coldStartMemory() = benchmarkRule.measureRepeated(
         packageName = TARGET_PACKAGE,
-        metrics = listOf(MemoryUsageMetric()),
+        metrics = listOf(MemoryUsageMetric(mode = MemoryUsageMetric.Mode.Max)),
         iterations = 3,
         startupMode = StartupMode.COLD
     ) {


### PR DESCRIPTION
## Summary
- call the stable `BaselineProfileRule.collect` API when generating baseline profiles and reuse the shared target package constant
- opt into the experimental memory metric API and provide an explicit `MemoryUsageMetric` mode so macrobenchmark tests compile

## Testing
- `./gradlew --console=plain connectedAndroidTest --stacktrace`


------
https://chatgpt.com/codex/tasks/task_e_68d7f25a2b90832bb0ad4e26f3d03b08