### PR TITLE
Fix release signing callback in Gradle script

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,9 +1,11 @@
 
 import com.android.build.api.dsl.ApplicationExtension
+import org.gradle.api.Action
 import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.UnknownTaskException
+import org.gradle.api.execution.TaskExecutionGraph
 import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.testing.Test
@@ -390,15 +392,19 @@ fun configureReleaseSigning() {
 if (needsReleaseSigning) {
     configureReleaseSigning()
 } else {
-    gradle.taskGraph.whenReady { taskGraph ->
-        if (taskGraph.allTasks.any { task ->
-                val taskName = task.name
-                taskName.targetsReleaseLikeVariant() && taskName.isPackagingOrPublishingTask()
+    gradle.taskGraph.whenReady(
+        object : Action<TaskExecutionGraph> {
+            override fun execute(taskGraph: TaskExecutionGraph) {
+                if (taskGraph.allTasks.any { task ->
+                        val taskName = task.name
+                        taskName.targetsReleaseLikeVariant() && taskName.isPackagingOrPublishingTask()
+                    }
+                ) {
+                    configureReleaseSigning()
+                }
             }
-        ) {
-            configureReleaseSigning()
         }
-    }
+    )
 }
 
 dependencies {


### PR DESCRIPTION
## Summary
- ensure release signing is configured lazily using a typed Action implementation
- add the necessary Gradle imports for Action-based task graph callbacks

## Testing
- `./gradlew --console=plain help` *(fails: missing Android SDK in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d801a1c9e4832b96c49ddcf7e6bcf0