### PR TITLE
Allow overriding app id for automation launches

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,12 +53,17 @@ plugins {
     id("jacoco")
 }
 
+val resolvedApplicationId = (findProperty("NOVAPDF_APP_ID") as? String)
+    ?.takeIf { it.isNotBlank() }
+    ?: System.getenv("NOVAPDF_APP_ID")?.takeIf { it.isNotBlank() }
+    ?: "com.novapdf.reader"
+
 android {
     namespace = "com.novapdf.reader"
     compileSdk = 35
 
     defaultConfig {
-        applicationId = "com.novapdf.reader"
+        applicationId = resolvedApplicationId
         minSdk = 21
         targetSdk = 35
         versionCode = 1

--- a/app/src/androidTest/kotlin/com/novapdf/reader/PdfViewerUiAutomatorTest.kt
+++ b/app/src/androidTest/kotlin/com/novapdf/reader/PdfViewerUiAutomatorTest.kt
@@ -28,7 +28,7 @@ import org.junit.runner.RunWith
 class PdfViewerUiAutomatorTest {
 
     @get:Rule
-    val activityRule = ActivityScenarioRule(MainActivity::class.java)
+    val activityRule = ActivityScenarioRule(ReaderActivity::class.java)
 
     private lateinit var device: UiDevice
     private lateinit var appContext: Context

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools">
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <!-- MANAGE_EXTERNAL_STORAGE is declared so API 30-33 users can opt in from the explicit
-         settings screen launched by MainActivity. Keeping the permission behind that settings
+         settings screen launched by ReaderActivity. Keeping the permission behind that settings
          flow lets us honour scoped storage/Play policy requirements while still enabling the
          in-app PDF library browser. -->
     <uses-permission
@@ -22,16 +22,21 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.NovaPDFReader">
         <activity
-            android:name="com.novapdf.reader.MainActivity"
+            android:name="com.novapdf.reader.ReaderActivity"
             android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"
             android:exported="true"
-            android:launchMode="singleTask">
+            android:launchMode="singleTask" />
+
+        <activity-alias
+            android:name=".MainActivity"
+            android:exported="true"
+            android:targetActivity="com.novapdf.reader.ReaderActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
-        </activity>
+        </activity-alias>
     </application>
 
 </manifest>

--- a/app/src/main/kotlin/com/novapdf/reader/ReaderActivity.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/ReaderActivity.kt
@@ -35,7 +35,7 @@ import com.google.android.material.progressindicator.CircularProgressIndicator
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.launch
 
-class MainActivity : ComponentActivity() {
+class ReaderActivity : ComponentActivity() {
     private val viewModel: PdfViewerViewModel by viewModels()
     private val snackbarHost = SnackbarHostState()
     private val preferences by lazy { getSharedPreferences(PERMISSION_PREFS, MODE_PRIVATE) }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -6,7 +6,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:fitsSystemWindows="true"
-    tools:context=".MainActivity">
+    tools:context=".ReaderActivity">
 
     <com.google.android.material.appbar.MaterialToolbar
         android:id="@+id/legacy_toolbar"


### PR DESCRIPTION
## Summary
- rename the launcher activity to ReaderActivity and expose an activity alias matching MainActivity for tooling
- allow the application id to be overridden through the NOVAPDF_APP_ID property or environment variable so screenshot jobs can target the correct package
- update tests and layout metadata to reference the renamed activity

## Testing
- ./gradlew testReleaseUnitTest *(fails: missing Android SDK configuration in CI container)*

------
https://chatgpt.com/codex/tasks/task_e_68d80f788a84832ba8dcf3b95f5a884d