### PR TITLE
Add concrete MainActivity for automation

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,16 +27,17 @@
             android:exported="true"
             android:launchMode="singleTask" />
 
-        <activity-alias
+        <activity
             android:name=".MainActivity"
+            android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"
             android:exported="true"
-            android:targetActivity="com.novapdf.reader.ReaderActivity">
+            android:launchMode="singleTask">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
-        </activity-alias>
+        </activity>
     </application>
 
 </manifest>

--- a/app/src/main/kotlin/com/novapdf/reader/MainActivity.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/MainActivity.kt
@@ -1,0 +1,8 @@
+package com.novapdf.reader
+
+/**
+ * Entry point activity used by automated UI tooling. This simply inherits from [ReaderActivity]
+ * so all of the existing behaviour remains unchanged while ensuring a concrete `MainActivity`
+ * class is packaged into the APK.
+ */
+class MainActivity : ReaderActivity()

--- a/app/src/main/kotlin/com/novapdf/reader/ReaderActivity.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/ReaderActivity.kt
@@ -35,7 +35,7 @@ import com.google.android.material.progressindicator.CircularProgressIndicator
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.launch
 
-class ReaderActivity : ComponentActivity() {
+open class ReaderActivity : ComponentActivity() {
     private val viewModel: PdfViewerViewModel by viewModels()
     private val snackbarHost = SnackbarHostState()
     private val preferences by lazy { getSharedPreferences(PERMISSION_PREFS, MODE_PRIVATE) }


### PR DESCRIPTION
## Summary
- add a concrete `MainActivity` class that extends the existing `ReaderActivity`
- update the manifest so the launcher intent resolves to the new activity for automation tooling

## Testing
- ./gradlew lint *(fails: missing Android SDK in CI runner)*

------
https://chatgpt.com/codex/tasks/task_e_68d817335c94832ba5c0ba7ecdfac314