### PR TITLE
Fix Pixel Tablet screenshot capture in CI

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -335,6 +335,8 @@ jobs:
           adb shell input keyevent 82 || true
       - name: Run instrumentation tests
         run: ./gradlew connectedAndroidTest --stacktrace
+      - name: Install debug build for screenshots
+        run: ./gradlew :app:installDebug --stacktrace
       - name: Capture screenshots
         run: |
           set -euo pipefail
@@ -381,10 +383,7 @@ jobs:
             sleep 4
 
             for i in $(seq -w 1 "$count"); do
-              remote="/sdcard/${label}_${i}.png"
-              adb shell screencap -p "$remote"
-              adb pull "$remote" "$target_dir/screenshot_${i}.png"
-              adb shell rm "$remote" || true
+              adb exec-out screencap -p > "$target_dir/screenshot_${i}.png"
               sleep 1
             done
           }


### PR DESCRIPTION
## Summary
- reinstall the debug variant after instrumentation tests so the launcher activity is available for screenshots
- stream emulator screencaps directly via adb exec-out instead of writing to /sdcard to avoid permission issues

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68d81d2d4484832bad19dece5f7ec392