### PR TITLE
Fix release bundle verification command

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -420,7 +420,7 @@ jobs:
           mkdir -p "$target_dir"
           signed_bundle="$target_dir/NovaPDFReader-release-signed-api${{ matrix.api }}-${{ matrix.device_label }}.aab"
           cp "$bundle_path" "$signed_bundle"
-          "$ANDROID_HOME"/build-tools/34.0.0/apksigner verify --print-certs "$signed_bundle"
+          jarsigner -verify -verbose -certs "$signed_bundle"
       - name: Stage test and lint reports
         if: always()
         run: |


### PR DESCRIPTION
## Summary
- replace the apksigner verification step with jarsigner so Android App Bundles validate correctly

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d827ef3780832b93528313e17214ba