### PR TITLE
Improve PDF loading responsiveness

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,6 +23,8 @@
     <string name="outline_page_label">Page %1$d</string>
     <string name="export_document">Export or share</string>
     <string name="export_failed">Unable to export the document. Try again.</string>
+    <string name="loading_document">Loading your document…</string>
+    <string name="loading_progress">%1$d%% processed</string>
     <string name="legacy_select_document">Open a PDF to start reading.</string>
     <string name="legacy_error_loading">Something went wrong while opening the PDF.</string>
     <string name="legacy_retry">Try again</string>


### PR DESCRIPTION
## Summary
- offload PDF opening and initial rendering work to background threads while reporting progress through the ViewModel state
- surface an in-app loading overlay that reflects document parsing progress for better user feedback
- add localized strings for the loading indicator copy

## Testing
- `./gradlew :app:lintDebug` *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d83350eeec832b842b538134270944