### PR TITLE
Improve adaptive flow jank handling

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -72,6 +72,13 @@ android {
         vectorDrawables.useSupportLibrary = true
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
+        buildConfigField("int", "LOW_END_MIN_PPM", "8")
+        buildConfigField("int", "LOW_END_MAX_PPM", "90")
+        buildConfigField("int", "HIGH_END_MIN_PPM", "12")
+        buildConfigField("int", "HIGH_END_MAX_PPM", "210")
+        buildConfigField("float", "ADAPTIVE_FLOW_JANK_FRAME_THRESHOLD_MS", "16.0f")
+        buildConfigField("long", "ADAPTIVE_FLOW_PRELOAD_COOLDOWN_MS", "750L")
+
     }
 
     signingConfigs {


### PR DESCRIPTION
## Summary
- add BuildConfig flags that define adaptive flow ppm ranges and frame handling thresholds
- integrate FrameMetricsAggregator-based jank detection into AdaptiveFlowManager and pause preloading during frame stalls
- expand unit tests to cover jank-induced backpressure and cooldown-based recovery

## Testing
- `./gradlew testDebugUnitTest` *(fails: Android SDK not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d834f55af4832ba6c397f67946562f