### PR TITLE
Revamp viewer search UI and fallback search

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,4 +29,11 @@
     <string name="legacy_error_loading">Something went wrong while opening the PDF.</string>
     <string name="legacy_retry">Try again</string>
     <string name="legacy_pdf_page">Page %1$d</string>
+    <string name="search_results_count">Matches: %1$d</string>
+    <string name="adaptive_flow_summary_title">Adaptive Flow</string>
+    <string name="adaptive_flow_summary_description">Speed: %1$.0f pages/min · Sensitivity: %2$.1f</string>
+    <string name="adaptive_flow_summary_button">Play summary</string>
+    <string name="adaptive_flow_summary_unavailable">Adaptive Flow paused</string>
+    <string name="empty_state_message">Open a PDF to start reading.</string>
+    <string name="empty_state_button">Open document</string>
 </resources>

--- a/app/src/test/kotlin/com/novapdf/reader/PdfViewerViewModelSearchTest.kt
+++ b/app/src/test/kotlin/com/novapdf/reader/PdfViewerViewModelSearchTest.kt
@@ -1,22 +1,18 @@
 package com.novapdf.reader
 
 import android.graphics.Bitmap
-import android.graphics.Canvas
-import android.graphics.Color
-import android.graphics.Matrix
-import android.graphics.Paint
-import android.graphics.Rect
-import android.graphics.RectF
-import android.graphics.pdf.PdfRenderer
 import android.net.Uri
 import android.os.ParcelFileDescriptor
+import android.util.Size
+import androidx.test.core.app.ApplicationProvider
 import com.novapdf.reader.data.AnnotationRepository
 import com.novapdf.reader.data.BookmarkManager
 import com.novapdf.reader.data.PdfDocumentRepository
 import com.novapdf.reader.data.PdfDocumentSession
 import com.novapdf.reader.work.DocumentMaintenanceScheduler
-import kotlinx.coroutines.ExperimentalCoroutinesApi
+import com.shockwave.pdfium.PdfDocument
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
@@ -28,16 +24,13 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import com.novapdf.reader.search.TextRunSnapshot
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 import org.mockito.kotlin.any
-import org.mockito.kotlin.anyOrNull
-import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(RobolectricTestRunner::class)
@@ -56,8 +49,8 @@ class PdfViewerViewModelSearchTest {
     }
 
     @Test
-    @Config(sdk = [34], application = TestPdfApp::class)
-    fun `performSearch extracts text runs on Api 34`() = runTest {
+    @Config(application = TestPdfApp::class)
+    fun `performSearch returns detected regions from rendered bitmap`() = runTest {
         val app = TestPdfApp.getInstance()
         val annotationRepository = mock<AnnotationRepository>()
         val pdfRepository = mock<PdfDocumentRepository>()
@@ -65,122 +58,30 @@ class PdfViewerViewModelSearchTest {
         val bookmarkManager = mock<BookmarkManager>()
         val maintenanceScheduler = mock<DocumentMaintenanceScheduler>()
 
-        val readingSpeed = MutableStateFlow(30f)
-        val swipeSensitivity = MutableStateFlow(1f)
-        val preloadTargets = MutableStateFlow(emptyList<Int>())
-
-        whenever(adaptiveFlowManager.readingSpeedPagesPerMinute).thenReturn(readingSpeed)
-        whenever(adaptiveFlowManager.swipeSensitivity).thenReturn(swipeSensitivity)
-        whenever(adaptiveFlowManager.preloadTargets).thenReturn(preloadTargets)
-
+        whenever(adaptiveFlowManager.readingSpeedPagesPerMinute).thenReturn(MutableStateFlow(30f))
+        whenever(adaptiveFlowManager.swipeSensitivity).thenReturn(MutableStateFlow(1f))
+        whenever(adaptiveFlowManager.preloadTargets).thenReturn(MutableStateFlow(emptyList()))
         whenever(annotationRepository.annotationsForDocument(any())).thenReturn(emptyList())
         whenever(bookmarkManager.bookmarks(any())).thenReturn(emptyList())
-
-        val renderer = mock<PdfRenderer>()
-        val page = mock<PdfRenderer.Page>()
-        whenever(page.width).thenReturn(220)
-        whenever(page.height).thenReturn(400)
-        whenever(renderer.openPage(0)).thenReturn(page)
 
         val session = PdfDocumentSession(
             documentId = "doc",
             uri = Uri.parse("file://doc"),
             pageCount = 1,
-            renderer = renderer,
+            document = mock<PdfDocument>(),
             fileDescriptor = mock<ParcelFileDescriptor>()
         )
-        val sessionFlow = MutableStateFlow<PdfDocumentSession?>(session)
-        whenever(pdfRepository.session).thenReturn(sessionFlow)
+        whenever(pdfRepository.session).thenReturn(MutableStateFlow(session))
+        whenever(pdfRepository.getPageSize(0)).thenReturn(Size(200, 280))
 
-        app.installDependencies(
-            annotationRepository,
-            pdfRepository,
-            adaptiveFlowManager,
-            bookmarkManager,
-            maintenanceScheduler
-        )
+        val bitmap = Bitmap.createBitmap(200, 280, Bitmap.Config.ARGB_8888)
+        bitmap.eraseColor(android.graphics.Color.WHITE)
+        val canvas = android.graphics.Canvas(bitmap)
+        val paint = android.graphics.Paint().apply { color = android.graphics.Color.BLACK }
+        canvas.drawRect(20f, 40f, 180f, 100f, paint)
+        canvas.drawRect(30f, 140f, 170f, 200f, paint)
 
-        val viewModel = object : PdfViewerViewModel(app) {
-            override fun extractTextRuns(page: PdfRenderer.Page): List<TextRunSnapshot> {
-                return listOf(
-                    TextRunSnapshot(
-                        text = "Lorem ipsum",
-                        bounds = listOf(
-                            RectF(0f, 0f, 100f, 40f),
-                            RectF(100f, 0f, 220f, 40f)
-                        )
-                    )
-                )
-            }
-        }
-
-        val matches = viewModel.performSearch(0, "lorem ipsum")
-
-        assertEquals(1, matches.size)
-        val match = matches.first()
-        assertEquals(0, match.indexInPage)
-        assertEquals(2, match.boundingBoxes.size)
-        val first = match.boundingBoxes[0]
-        val second = match.boundingBoxes[1]
-        assertTrue(first.left <= 0.01f)
-        assertTrue(first.right > 0.45f)
-        assertTrue(second.left > 0.45f)
-        assertTrue(second.right > 0.9f)
-
-        verify(page).close()
-    }
-
-    @Test
-    @Config(sdk = [33], application = TestPdfApp::class)
-    fun `performSearch falls back to bitmap detection below Api 34`() = runTest {
-        val app = TestPdfApp.getInstance()
-        val annotationRepository = mock<AnnotationRepository>()
-        val pdfRepository = mock<PdfDocumentRepository>()
-        val adaptiveFlowManager = mock<AdaptiveFlowManager>()
-        val bookmarkManager = mock<BookmarkManager>()
-        val maintenanceScheduler = mock<DocumentMaintenanceScheduler>()
-
-        val readingSpeed = MutableStateFlow(30f)
-        val swipeSensitivity = MutableStateFlow(1f)
-        val preloadTargets = MutableStateFlow(emptyList<Int>())
-
-        whenever(adaptiveFlowManager.readingSpeedPagesPerMinute).thenReturn(readingSpeed)
-        whenever(adaptiveFlowManager.swipeSensitivity).thenReturn(swipeSensitivity)
-        whenever(adaptiveFlowManager.preloadTargets).thenReturn(preloadTargets)
-
-        whenever(annotationRepository.annotationsForDocument(any())).thenReturn(emptyList())
-        whenever(bookmarkManager.bookmarks(any())).thenReturn(emptyList())
-
-        val renderer = mock<PdfRenderer>()
-        val page = mock<PdfRenderer.Page>()
-        whenever(page.width).thenReturn(200)
-        whenever(page.height).thenReturn(200)
-
-        doAnswer {
-            val bitmap = it.getArgument<Bitmap>(0)
-            val canvas = Canvas(bitmap)
-            canvas.drawColor(Color.WHITE)
-            val paint = Paint().apply { color = Color.BLACK }
-            canvas.drawRect(Rect(10, 20, 90, 60), paint)
-            canvas.drawRect(Rect(110, 120, 190, 160), paint)
-            Unit
-        }.whenever(page).render(
-            any<Bitmap>(),
-            anyOrNull<Rect>(),
-            anyOrNull<Matrix>(),
-            eq(PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
-        )
-        whenever(renderer.openPage(0)).thenReturn(page)
-
-        val session = PdfDocumentSession(
-            documentId = "doc",
-            uri = Uri.parse("file://doc"),
-            pageCount = 1,
-            renderer = renderer,
-            fileDescriptor = mock<ParcelFileDescriptor>()
-        )
-        val sessionFlow = MutableStateFlow<PdfDocumentSession?>(session)
-        whenever(pdfRepository.session).thenReturn(sessionFlow)
+        whenever(pdfRepository.renderPage(eq(0), eq(720))).thenReturn(bitmap)
 
         app.installDependencies(
             annotationRepository,
@@ -197,20 +98,52 @@ class PdfViewerViewModelSearchTest {
         assertEquals(1, matches.size)
         val match = matches.first()
         assertEquals(0, match.indexInPage)
-        assertEquals(2, match.boundingBoxes.size)
-        val first = match.boundingBoxes[0]
-        val second = match.boundingBoxes[1]
-        assertTrue(first.top < second.top)
-        assertTrue(first.left < first.right)
-        assertTrue(second.left < second.right)
+        assertTrue(match.boundingBoxes.size >= 2)
+        assertTrue(bitmap.isRecycled)
+        verify(pdfRepository).renderPage(eq(0), eq(720))
+    }
 
-        verify(page).render(
-            any<Bitmap>(),
-            anyOrNull<Rect>(),
-            anyOrNull<Matrix>(),
-            eq(PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
+    @Test
+    @Config(application = TestPdfApp::class)
+    fun `performSearch returns empty list when rendering fails`() = runTest {
+        val app = TestPdfApp.getInstance()
+        val annotationRepository = mock<AnnotationRepository>()
+        val pdfRepository = mock<PdfDocumentRepository>()
+        val adaptiveFlowManager = mock<AdaptiveFlowManager>()
+        val bookmarkManager = mock<BookmarkManager>()
+        val maintenanceScheduler = mock<DocumentMaintenanceScheduler>()
+
+        whenever(adaptiveFlowManager.readingSpeedPagesPerMinute).thenReturn(MutableStateFlow(30f))
+        whenever(adaptiveFlowManager.swipeSensitivity).thenReturn(MutableStateFlow(1f))
+        whenever(adaptiveFlowManager.preloadTargets).thenReturn(MutableStateFlow(emptyList()))
+        whenever(annotationRepository.annotationsForDocument(any())).thenReturn(emptyList())
+        whenever(bookmarkManager.bookmarks(any())).thenReturn(emptyList())
+
+        val session = PdfDocumentSession(
+            documentId = "doc",
+            uri = Uri.parse("file://doc"),
+            pageCount = 1,
+            document = mock<PdfDocument>(),
+            fileDescriptor = mock<ParcelFileDescriptor>()
         )
-        verify(page).close()
+        whenever(pdfRepository.session).thenReturn(MutableStateFlow(session))
+        whenever(pdfRepository.getPageSize(0)).thenReturn(Size(200, 280))
+        whenever(pdfRepository.renderPage(eq(0), eq(720))).thenReturn(null)
+
+        app.installDependencies(
+            annotationRepository,
+            pdfRepository,
+            adaptiveFlowManager,
+            bookmarkManager,
+            maintenanceScheduler
+        )
+
+        val viewModel = PdfViewerViewModel(app)
+
+        val matches = viewModel.performSearch(0, "hello")
+
+        assertTrue(matches.isEmpty())
+        verify(pdfRepository).renderPage(eq(0), eq(720))
     }
 
     class TestPdfApp : NovaPdfApp() {
@@ -240,9 +173,8 @@ class PdfViewerViewModelSearchTest {
 
         companion object {
             fun getInstance(): TestPdfApp {
-                return androidx.test.core.app.ApplicationProvider.getApplicationContext()
+                return ApplicationProvider.getApplicationContext()
             }
         }
     }
 }
-


### PR DESCRIPTION
## Summary
- add dedicated composables for the search bar, adaptive flow status, accessibility toggles, and empty state in the viewer screen
- update PdfViewerViewModel search logic to render pages through Pdfium and detect text regions without PdfRenderer dependencies
- extend UI strings and refresh unit tests to cover the bitmap-based search fallback

## Testing
- `./gradlew testDebugUnitTest --info` *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d83fc1c0e8832bb5349344b5b99fce