### PR TITLE
Downgrade Caffeine to support minSdk 21

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -444,7 +444,8 @@ dependencies {
     implementation("androidx.security:security-crypto:1.1.0-alpha06")
     implementation("androidx.profileinstaller:profileinstaller:1.3.1")
     implementation("com.github.barteksc:pdfium-android:1.9.0")
-    implementation("com.github.ben-manes.caffeine:caffeine:3.1.8")
+    // Caffeine 3.x requires minSdk 26+ due to MethodHandle usage; stick to 2.x for API 21 support
+    implementation("com.github.ben-manes.caffeine:caffeine:2.9.3")
 
     implementation("androidx.room:room-runtime:2.6.1")
     implementation("androidx.room:room-ktx:2.6.1")


### PR DESCRIPTION
## Summary
- downgrade the Caffeine dependency to the latest 2.x release that remains compatible with the app's minSdk 21
- document why the project stays on the 2.x series to avoid MethodHandle usage that requires API level 26

## Testing
- ./gradlew assembleDebug *(fails: SDK location not found in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d88e37ee54832bb0d1a00f4ba54fe7