### PR TITLE
Exclude legacy support compat from pdfium dependency

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -443,7 +443,9 @@ dependencies {
     implementation("androidx.work:work-runtime-ktx:2.9.0")
     implementation("androidx.security:security-crypto:1.1.0-alpha06")
     implementation("androidx.profileinstaller:profileinstaller:1.3.1")
-    implementation("com.github.barteksc:pdfium-android:1.9.0")
+    implementation("com.github.barteksc:pdfium-android:1.9.0") {
+        exclude(group = "com.android.support", module = "support-compat")
+    }
     // Caffeine 3.x requires minSdk 26+ due to MethodHandle usage; stick to 2.x for API 21 support
     implementation("com.github.ben-manes.caffeine:caffeine:2.9.3")
 


### PR DESCRIPTION
## Summary
- exclude the obsolete com.android.support:support-compat artifact from the pdfium dependency to avoid duplicate class conflicts when building instrumentation variants

## Testing
- ./gradlew connectedAndroidTest --stacktrace *(fails: Android SDK not found in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8925b9a1c832b940326c318219d28