### PR TITLE
Handle missing Android SDK in baseline profile module

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -58,6 +58,8 @@ val resolvedApplicationId = (findProperty("NOVAPDF_APP_ID") as? String)
     ?: System.getenv("NOVAPDF_APP_ID")?.takeIf { it.isNotBlank() }
     ?: "com.novapdf.reader"
 
+val baselineProfileProject = rootProject.findProject(":baselineprofile")
+
 android {
     namespace = "com.novapdf.reader"
     compileSdk = 35
@@ -475,7 +477,7 @@ dependencies {
     androidTestUtil("androidx.test:orchestrator:1.4.2")
     debugImplementation("androidx.compose.ui:ui-tooling")
     debugImplementation("androidx.compose.ui:ui-test-manifest")
-    baselineProfile(project(":baselineprofile"))
+    baselineProfileProject?.let { baselineProfile(it) }
 }
 
 kotlin {

--- a/baselineprofile/build.gradle.kts
+++ b/baselineprofile/build.gradle.kts
@@ -3,7 +3,41 @@ import com.android.build.api.variant.TestAndroidComponentsExtension
 import org.gradle.api.GradleException
 import org.gradle.api.JavaVersion
 import java.io.File
+import java.util.Properties
 import java.util.concurrent.TimeUnit
+
+val rootLocalProperties = rootProject.file("local.properties")
+val configuredAndroidSdk = listOfNotNull(
+    providers.environmentVariable("ANDROID_SDK_ROOT").orNull,
+    providers.environmentVariable("ANDROID_HOME").orNull
+).firstOrNull { it.isNotBlank() }
+
+if (!rootLocalProperties.exists() && configuredAndroidSdk == null) {
+    val fallbackSdkDir = listOfNotNull(
+        System.getenv("ANDROID_SDK_ROOT"),
+        System.getenv("ANDROID_HOME"),
+        "/usr/local/lib/android/sdk"
+    )
+        .map { it.trim() }
+        .firstOrNull { it.isNotEmpty() && File(it).exists() }
+
+    if (fallbackSdkDir != null) {
+        val properties = Properties().apply {
+            setProperty("sdk.dir", File(fallbackSdkDir).absolutePath.replace("\\", "\\\\"))
+        }
+        rootLocalProperties.outputStream().use { output ->
+            properties.store(
+                output,
+                "Auto-generated to help Gradle locate the Android SDK on environments without local.properties"
+            )
+        }
+        logger.lifecycle("Created local.properties with sdk.dir at ${fallbackSdkDir} for baseline profile configuration.")
+    } else {
+        logger.warn(
+            "Unable to locate an Android SDK. Set ANDROID_SDK_ROOT or ANDROID_HOME, or create local.properties with sdk.dir."
+        )
+    }
+}
 
 plugins {
     id("com.android.test")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,6 @@
+import java.io.File
+import java.util.Properties
+
 pluginManagement {
     repositories {
         google()
@@ -16,4 +19,50 @@ dependencyResolutionManagement {
 
 rootProject.name = "NovaPDFReader"
 include(":app")
-include(":baselineprofile")
+
+fun discoverAndroidSdk(rootDir: File): File? {
+    val localPropertiesFile = File(rootDir, "local.properties")
+    val localPropertiesSdk = if (localPropertiesFile.exists()) {
+        runCatching {
+            Properties().apply {
+                localPropertiesFile.inputStream().use { load(it) }
+            }.getProperty("sdk.dir")
+        }.getOrNull()?.trim()?.takeIf { it.isNotEmpty() }
+    } else {
+        null
+    }
+
+    val candidates = listOfNotNull(
+        System.getenv("ANDROID_SDK_ROOT"),
+        System.getenv("ANDROID_HOME"),
+        localPropertiesSdk,
+        "/usr/local/lib/android/sdk"
+    )
+        .map { it.trim() }
+        .filter { it.isNotEmpty() }
+        .map { File(it) }
+
+    return candidates.firstOrNull { it.exists() }
+}
+
+val discoveredAndroidSdk = discoverAndroidSdk(rootDir)
+
+if (discoveredAndroidSdk != null) {
+    val localPropertiesFile = File(rootDir, "local.properties")
+    if (!localPropertiesFile.exists()) {
+        val properties = Properties().apply {
+            setProperty("sdk.dir", discoveredAndroidSdk.absolutePath.replace("\\", "\\\\"))
+        }
+        localPropertiesFile.outputStream().use { output ->
+            properties.store(
+                output,
+                "Auto-generated to help Gradle locate the Android SDK on environments without local.properties"
+            )
+        }
+        println("Created local.properties with sdk.dir=${discoveredAndroidSdk.absolutePath}")
+    }
+
+    include(":baselineprofile")
+} else {
+    println("Skipping :baselineprofile because no Android SDK was detected. Set ANDROID_SDK_ROOT/ANDROID_HOME or local.properties sdk.dir to enable it.")
+}


### PR DESCRIPTION
## Summary
- detect the Android SDK location when settings are evaluated and only include the baseline profile module when one is available
- auto-generate a local.properties file with sdk.dir when a known SDK path is discovered
- guard the app module's baselineProfile dependency so builds continue when the module is skipped

## Testing
- `./gradlew assembleDebug` *(fails: Android SDK is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8f9036aa0832b9fbf77e7b5f6b235