### PR TITLE
Fix Compose compilation issues in typography and page gradient

### DIFF
--- a/app/src/main/kotlin/com/novapdf/reader/PdfViewerScreen.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/PdfViewerScreen.kt
@@ -869,11 +869,12 @@ private fun PdfPageItem(
         )
         val pageShape = MaterialTheme.shapes.extraLarge
         val elevatedSurface = MaterialTheme.colorScheme.surfaceColorAtElevation(6.dp)
-        val gradientColors = remember(MaterialTheme.colorScheme.primary, MaterialTheme.colorScheme.secondary) {
+        val colorScheme = MaterialTheme.colorScheme
+        val gradientColors = remember(colorScheme.primary, colorScheme.secondary) {
             listOf(
-                MaterialTheme.colorScheme.primary.copy(alpha = 0.4f),
+                colorScheme.primary.copy(alpha = 0.4f),
                 Color.Transparent,
-                MaterialTheme.colorScheme.secondary.copy(alpha = 0.4f)
+                colorScheme.secondary.copy(alpha = 0.4f)
             )
         }
         var showPageFlip by remember(state.documentId, pageIndex) { mutableStateOf(false) }

--- a/app/src/main/kotlin/com/novapdf/reader/ui/theme/Type.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/ui/theme/Type.kt
@@ -3,7 +3,6 @@ package com.novapdf.reader.ui.theme
 import androidx.compose.material3.Typography
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.text.font.FontVariation
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
 import com.novapdf.reader.R
@@ -11,28 +10,23 @@ import com.novapdf.reader.R
 private val robotoFlexFamily = FontFamily(
     Font(
         resId = R.font.roboto_flex_variable,
-        weight = FontWeight.Light,
-        variationSettings = FontVariation.Settings(FontVariation.Axis.Weight, 300f)
+        weight = FontWeight.Light
     ),
     Font(
         resId = R.font.roboto_flex_variable,
-        weight = FontWeight.Normal,
-        variationSettings = FontVariation.Settings(FontVariation.Axis.Weight, 400f)
+        weight = FontWeight.Normal
     ),
     Font(
         resId = R.font.roboto_flex_variable,
-        weight = FontWeight.Medium,
-        variationSettings = FontVariation.Settings(FontVariation.Axis.Weight, 500f)
+        weight = FontWeight.Medium
     ),
     Font(
         resId = R.font.roboto_flex_variable,
-        weight = FontWeight.SemiBold,
-        variationSettings = FontVariation.Settings(FontVariation.Axis.Weight, 600f)
+        weight = FontWeight.SemiBold
     ),
     Font(
         resId = R.font.roboto_flex_variable,
-        weight = FontWeight.Bold,
-        variationSettings = FontVariation.Settings(FontVariation.Axis.Weight, 700f)
+        weight = FontWeight.Bold
     )
 )
 


### PR DESCRIPTION
## Summary
- remove usage of experimental FontVariation axis APIs from the Roboto Flex font family
- avoid calling composable MaterialTheme properties from remember keys when building page gradients

## Testing
- `./gradlew :app:compileDebugKotlin` *(fails: SDK location not found in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8ff08d8a8832b989cec1b503cc453