### PR TITLE
Fix missing closing brace in PdfViewerScreen

### DIFF
--- a/app/src/main/kotlin/com/novapdf/reader/PdfViewerScreen.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/PdfViewerScreen.kt
@@ -354,6 +354,8 @@ fun PdfViewerScreen(
     }
 }
 
+}
+
 @Composable
 private fun LoadingOverlay(progress: Float?) {
     Box(


### PR DESCRIPTION
## Summary
- add the missing closing brace to PdfViewerScreen so the composable function closes correctly

## Testing
- ./gradlew :app:kaptGenerateStubsDebugKotlin *(fails: SDK location not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d90caa46ec832b9b333562da787aef