### PR TITLE
Fix accessibility announcement dispatch for PdfViewerScreen

### DIFF
--- a/app/src/main/kotlin/com/novapdf/reader/PdfViewerScreen.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/PdfViewerScreen.kt
@@ -793,7 +793,7 @@ private fun AccessibilityManager?.sendAnnouncement(message: String) {
         eventType = AccessibilityEvent.TYPE_ANNOUNCEMENT
         text.add(message)
     }
-    manager.sendEvent(event)
+    manager.sendAccessibilityEvent(event)
 }
 
 @Composable


### PR DESCRIPTION
## Summary
- replace the deprecated AccessibilityManager#sendEvent call with sendAccessibilityEvent in PdfViewerScreen
- ensure accessibility announcements compile against the Android SDK

## Testing
- `./gradlew :app:compileDebugKotlin` *(fails: SDK location not found in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9132c8d98832b907312bd43819b4e