### PR TITLE
Add package manager readiness wait before installing APK

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -360,6 +360,18 @@ jobs:
             fi
           done
 
+          echo "Waiting for package manager service to become available"
+          pm_deadline=$((5 * 60))
+          pm_elapsed=0
+          until adb shell cmd package list packages >/dev/null 2>&1; do
+            sleep 5
+            pm_elapsed=$((pm_elapsed + 5))
+            if [ $pm_elapsed -ge $pm_deadline ]; then
+              echo "Package manager service did not become available within $((pm_deadline / 60)) minutes" >&2
+              exit 1
+            fi
+          done
+
           echo "Installing $apk_path onto the emulator"
           adb install -r "$apk_path"
       - name: Capture screenshots


### PR DESCRIPTION
## Summary
- wait for the Android package manager service to become available before installing the debug APK in CI
- fail fast with a clear error message if the package manager does not appear in time

## Testing
- not run (CI workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68d91e17a1d4832b940f4224409b785d