### PR TITLE
Add onboarding and navigation enhancements

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -53,4 +53,24 @@
     <string name="empty_state_message">Discover knowledge, one page at a time.</string>
     <string name="empty_state_button">Open document</string>
     <string name="empty_state_supporting">Import a PDF or revisit your saved library to keep your learning streak alive.</string>
+    <string name="home_welcome_title">Welcome to your PDF library</string>
+    <string name="home_welcome_body">Organize your documents and jump back into recent reads with a single tap.</string>
+    <string name="annotations_title">Annotations at a glance</string>
+    <string name="annotations_summary">You have %1$d in-document notes ready to review.</string>
+    <string name="annotations_empty">Add highlights or drawings while reading to see them collected here.</string>
+    <string name="onboarding_page_library_title">Build your library</string>
+    <string name="onboarding_page_library_description">Import PDFs and keep favorites close for offline reading.</string>
+    <string name="onboarding_page_annotation_title">Annotate effortlessly</string>
+    <string name="onboarding_page_annotation_description">Sketch, highlight, and capture notes with responsive tools.</string>
+    <string name="onboarding_page_search_title">Search smarter</string>
+    <string name="onboarding_page_search_description">Find key passages instantly with full-text search and filters.</string>
+    <string name="onboarding_skip">Skip</string>
+    <string name="onboarding_next">Next</string>
+    <string name="onboarding_get_started">Get started</string>
+    <string name="navigation_home">Home</string>
+    <string name="navigation_reader">Reader</string>
+    <string name="navigation_annotations">Annotations</string>
+    <string name="navigation_settings">Settings</string>
+    <string name="save_annotations">Save annotations</string>
+    <string name="toggle_bookmark">Toggle bookmark</string>
 </resources>


### PR DESCRIPTION
## Summary
- add a first-run onboarding pager with skip handling to introduce core reader features
- restructure the reader scaffold with bottom navigation, semantic text updates, and a persistent search FAB
- extend strings with copy for onboarding, navigation, and annotation summaries

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d927eac8d0832b96a4da9b685b0b60