### PR TITLE
Raise minSdk to 24

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -66,7 +66,7 @@ android {
 
     defaultConfig {
         applicationId = resolvedApplicationId
-        minSdk = 21
+        minSdk = 24
         targetSdk = 35
         versionCode = 1
         versionName = "1.0.0"
@@ -450,7 +450,7 @@ dependencies {
     implementation("com.github.barteksc:pdfium-android:1.9.0") {
         exclude(group = "com.android.support", module = "support-compat")
     }
-    // Caffeine 3.x requires minSdk 26+ due to MethodHandle usage; stick to 2.x for API 21 support
+    // Caffeine 3.x requires minSdk 26+ due to MethodHandle usage; stick to 2.x for API 24 support
     implementation("com.github.ben-manes.caffeine:caffeine:2.9.3")
 
     implementation("androidx.room:room-runtime:2.6.1")


### PR DESCRIPTION
## Summary
- increase the application's minSdk to 24 so manifest merging succeeds with the latest Compose artifacts
- refresh the Caffeine dependency comment to reflect the higher minimum API level

## Testing
- ./gradlew :app:processDebugMainManifest


------
https://chatgpt.com/codex/tasks/task_e_68d93912ff30832b8a7fb69e30f61464