### PR TITLE
Enable Gradle-managed Android SDK downloads

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,3 +12,5 @@ android.experimental.art-profile-r8-rewriting=true
 org.gradle.jvm.toolchain.installations.auto-download=true
 org.gradle.jvm.toolchain.installations.auto-detect=true
 android.suppressUnsupportedCompileSdk=35
+# Allow AGP to fetch missing command line SDK dependencies when no local installation is present.
+android.experimental.sdkDownload=true


### PR DESCRIPTION
## Summary
- enable the Android Gradle Plugin's experimental SDK downloader so builds can fetch missing command line components automatically

## Testing
- `./gradlew assembleDebug` *(fails: no Android SDK available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d93c90a42c832b9c3d2af93f64f852