### PR TITLE
Support managed SDK downloads in settings script

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -74,7 +74,7 @@
     <string name="save_annotations">Save annotations</string>
     <string name="toggle_bookmark">Toggle bookmark</string>
     <string name="open_source_dialog_title">Where is your PDF?</string>
-    <string name="open_source_dialog_body">Choose how you'd like to open your document.</string>
+    <string name="open_source_dialog_body">Choose how you\'d like to open your document.</string>
     <string name="open_source_device">Browse device storage</string>
     <string name="open_source_cloud">Select from Drive or OneDrive</string>
     <string name="open_source_url">Enter a web link</string>
@@ -87,12 +87,12 @@
     <string name="action_cancel">Cancel</string>
     <string name="action_try_again">Try again</string>
     <string name="action_repair_pdf">Try repairing the file</string>
-    <string name="error_pdf_dialog_title">We couldn't open this PDF</string>
+    <string name="error_pdf_dialog_title">We couldn\'t open this PDF</string>
     <string name="error_pdf_dialog_body">The file might be damaged. You can retry or use an online repair tool.</string>
-    <string name="error_pdf_corrupted">The PDF appears to be corrupted and can't be opened.</string>
-    <string name="error_pdf_unsupported">This file isn't a supported PDF document.</string>
-    <string name="error_pdf_permission">NovaPDF Reader doesn't have permission to read this file.</string>
-    <string name="error_document_open_generic">We couldn't open the document. Please try again.</string>
+    <string name="error_pdf_corrupted">The PDF appears to be corrupted and can\'t be opened.</string>
+    <string name="error_pdf_unsupported">This file isn\'t a supported PDF document.</string>
+    <string name="error_pdf_permission">NovaPDF Reader doesn\'t have permission to read this file.</string>
+    <string name="error_document_open_generic">We couldn\'t open the document. Please try again.</string>
     <string name="error_remote_open_failed">Download failed. Check the link and try again.</string>
     <string name="error_no_browser">No browser found to open the repair link.</string>
     <string name="remote_pdf_download_started">Downloading PDF…</string>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -20,6 +20,55 @@ dependencyResolutionManagement {
 rootProject.name = "NovaPDFReader"
 include(":app")
 
+fun isSdkDownloadEnabled(rootDir: File): Boolean {
+    val gradlePropertiesFile = File(rootDir, "gradle.properties")
+    if (!gradlePropertiesFile.exists()) {
+        return false
+    }
+
+    val properties = Properties().apply {
+        gradlePropertiesFile.inputStream().use { load(it) }
+    }
+
+    val raw = properties.getProperty("android.experimental.sdkDownload")?.trim()?.lowercase()
+    return raw == "true" || raw == "1" || raw == "yes"
+}
+
+fun ensureManagedSdkLicenses(managedSdkDirectory: File) {
+    val licensesDir = managedSdkDirectory.resolve("licenses").apply { mkdirs() }
+
+    fun File.ensureHashes(vararg hashes: String) {
+        val existing = if (exists()) {
+            readLines().map { it.trim() }.filter { it.isNotEmpty() }.toMutableSet()
+        } else {
+            mutableSetOf()
+        }
+
+        var updated = false
+        for (hash in hashes) {
+            if (existing.add(hash)) {
+                updated = true
+            }
+        }
+
+        if (updated || !exists()) {
+            writeText((existing.joinToString(System.lineSeparator())) + System.lineSeparator())
+        }
+    }
+
+    licensesDir.resolve("android-sdk-license").ensureHashes(
+        "d56f5187479451eabf01fb78af6dfcb131a6481e",
+        "24333f8a63b6825ea9c5514f83c2829b004d1fee",
+        "e9acab5b5fbb560a8e5d531e0f0d5797189a202a",
+        "7b5f888b0de5cd1284a08f9f4168c1b724f8a513"
+    )
+
+    licensesDir.resolve("android-sdk-preview-license").ensureHashes(
+        "84831b9409646a918e30573bab4c9c91346d8abd",
+        "504667f4c0de7af1a06de9f4b1727b84351f2910"
+    )
+}
+
 fun discoverAndroidSdk(rootDir: File): File? {
     val localPropertiesFile = File(rootDir, "local.properties")
     val localPropertiesSdk = if (localPropertiesFile.exists()) {
@@ -42,7 +91,25 @@ fun discoverAndroidSdk(rootDir: File): File? {
         .filter { it.isNotEmpty() }
         .map { File(it) }
 
-    return candidates.firstOrNull { it.exists() }
+    val managedSdkDirectory = File(rootDir, ".gradle/android-sdk")
+
+    val discovered = candidates.firstOrNull { it.exists() }
+    if (discovered != null) {
+        if (discovered.absoluteFile == managedSdkDirectory.absoluteFile) {
+            ensureManagedSdkLicenses(managedSdkDirectory)
+        }
+        return discovered
+    }
+
+    if (!isSdkDownloadEnabled(rootDir)) {
+        return null
+    }
+
+    if (!managedSdkDirectory.exists()) {
+        managedSdkDirectory.mkdirs()
+    }
+    ensureManagedSdkLicenses(managedSdkDirectory)
+    return managedSdkDirectory
 }
 
 val discoveredAndroidSdk = discoverAndroidSdk(rootDir)


### PR DESCRIPTION
## Summary
- ensure settings.gradle.kts provisions a managed Android SDK directory, seeds license hashes, and honors the sdkDownload flag so Gradle can bootstrap missing toolchains
- escape apostrophes in error dialog string resources to prevent aapt2 from flagging invalid unicode escape sequences during resource compilation

## Testing
- ./gradlew assembleDebug --console=plain *(fails: existing unresolved references in PdfViewerScreen.kt and PdfDownload* classes)*

------
https://chatgpt.com/codex/tasks/task_e_68d93ed63ba8832bb868cec9a336f0af