### PR TITLE
Fix download dialog build errors

### DIFF
--- a/app/src/main/kotlin/com/novapdf/reader/PdfViewerScreen.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/PdfViewerScreen.kt
@@ -68,6 +68,7 @@ import androidx.compose.material.icons.outlined.List
 import androidx.compose.material.icons.outlined.Share
 import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material.icons.outlined.MenuBook
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.CircularProgressIndicator

--- a/app/src/main/kotlin/com/novapdf/reader/data/remote/PdfDownloadDecoder.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/data/remote/PdfDownloadDecoder.kt
@@ -9,7 +9,6 @@ import coil3.decode.Decoder
 import coil3.fetch.SourceFetchResult
 import coil3.getExtra
 import coil3.request.Options
-import coil3.util.closeQuietly
 import java.io.File
 import okio.buffer
 import okio.sink
@@ -33,7 +32,7 @@ internal class PdfDownloadDecoder(
             payload.onDownloadFailed(throwable)
             throw throwable
         } finally {
-            imageSource.closeQuietly()
+            runCatching { imageSource.close() }
         }
         val placeholder = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888).apply {
             eraseColor(Color.TRANSPARENT)

--- a/app/src/main/kotlin/com/novapdf/reader/data/remote/PdfDownloadManager.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/data/remote/PdfDownloadManager.kt
@@ -42,9 +42,11 @@ class PdfDownloadManager(
         )
         val request = ImageRequest.Builder(appContext)
             .data(url)
-            .extras { set(PdfDownloadDecoder.PAYLOAD_KEY, payload) }
+            .apply {
+                extras.set(PdfDownloadDecoder.PAYLOAD_KEY, payload)
+            }
             .listener(
-                onError = { _, result ->
+                onError = { _: ImageRequest, result: ErrorResult ->
                     if (!deferred.isCompleted) {
                         deferred.completeExceptionally(result.throwable)
                     }


### PR DESCRIPTION
## Summary
- add the missing Material3 AlertDialog import so dialog composables compile
- switch the Coil decoder cleanup to the public close API
- update the download request to populate extras through the builder to match Coil 3

## Testing
- `./gradlew :app:compileDebugKotlin --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_68d94489cf54832b95b64df135133447