### PR TITLE
Add retry logic for emulator APK installation

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -373,7 +373,35 @@ jobs:
           done
 
           echo "Installing $apk_path onto the emulator"
-          adb install -r "$apk_path"
+          install_attempt=1
+          install_attempts_max=3
+          while true; do
+            if adb install -r "$apk_path"; then
+              break
+            fi
+
+            if [ $install_attempt -ge $install_attempts_max ]; then
+              echo "Failed to install $apk_path after $install_attempts_max attempts" >&2
+              exit 1
+            fi
+
+            install_attempt=$((install_attempt + 1))
+            echo "adb install failed (attempt $((install_attempt - 1))) — waiting for package manager before retrying"
+
+            retry_deadline=$((2 * 60))
+            retry_elapsed=0
+            until adb shell cmd package list packages >/dev/null 2>&1; do
+              sleep 5
+              retry_elapsed=$((retry_elapsed + 5))
+              if [ $retry_elapsed -ge $retry_deadline ]; then
+                echo "Package manager did not recover within $((retry_deadline / 60)) minutes after failed install" >&2
+                exit 1
+              fi
+            done
+
+            sleep 5
+            echo "Retrying adb install (attempt $install_attempt of $install_attempts_max)"
+          done
       - name: Capture screenshots
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary
- add retry logic for the adb install step when pushing the debug APK to the emulator in CI
- wait for the package manager service between retries and fail with a clearer message if it never recovers

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68d953cfe89c832bb4837321914b8cb4