### PR TITLE
Disable streamed adb install in CI workflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -376,7 +376,7 @@ jobs:
           install_attempt=1
           install_attempts_max=3
           while true; do
-            if adb install -r "$apk_path"; then
+            if adb install --no-streaming -r "$apk_path"; then
               break
             fi
 


### PR DESCRIPTION
## Summary
- switch the CI screenshot install step to use `adb install --no-streaming` to avoid StorageManager null pointer crashes on API 34 emulators

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9598ef454832baff8ad9a872eab4f