### PR TITLE
Fix Lucene dependency resolution for build

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -452,8 +452,9 @@ dependencies {
     }
     // Caffeine 3.x requires minSdk 26+ due to MethodHandle usage; stick to 2.x for API 24 support
     implementation("com.github.ben-manes.caffeine:caffeine:2.9.3")
-    implementation("org.apache.lucene:lucene-core:9.10.0")
-    implementation("org.apache.lucene:lucene-analyzers-common:9.10.0")
+    implementation("org.apache.lucene:lucene-core:8.11.4")
+    implementation("org.apache.lucene:lucene-analyzers-common:8.11.4")
+    implementation("org.apache.lucene:lucene-queryparser:8.11.4")
     implementation("com.tom-roush:pdfbox-android:2.0.27.0")
     implementation("com.google.mlkit:text-recognition:16.0.0")
 

--- a/app/src/main/kotlin/com/novapdf/reader/PdfViewerViewModel.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/PdfViewerViewModel.kt
@@ -1,6 +1,7 @@
 package com.novapdf.reader
 
 import android.app.Application
+import android.graphics.Bitmap
 import android.graphics.Rect
 import android.net.Uri
 import android.util.Log

--- a/app/src/main/kotlin/com/novapdf/reader/search/LuceneSearchCoordinator.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/search/LuceneSearchCoordinator.kt
@@ -75,7 +75,7 @@ class LuceneSearchCoordinator(
         ensureIndexReady(session)
         val searcher = indexSearcher ?: return emptyList()
         val luceneQuery = buildQuery(query)
-        val maxDocs = max(1, searcher.indexReader.maxDoc)
+        val maxDocs = max(1, searcher.indexReader.maxDoc())
         val topDocs = try {
             searcher.search(luceneQuery, maxDocs)
         } catch (parse: Exception) {


### PR DESCRIPTION
## Summary
- replace the unavailable Lucene 9.10 analyzer artifact with the supported 8.11.4 modules
- add the required lucene-queryparser dependency and import android.graphics.Bitmap
- adjust the search coordinator to call `maxDoc()` with the updated Lucene API

## Testing
- ./gradlew testDebugUnitTest --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d96a8bc8b8832baf4a66414d0e2d78