### PR TITLE
Suppress R8 missing class error for optional JP2 decoder

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -2,3 +2,6 @@
 -keep class android.graphics.pdf.** { *; }
 -keepclassmembers class com.novapdf.reader.** { *; }
 -dontwarn javax.annotation.**
+# pdfbox-android references an optional JPEG2000 decoder which isn't bundled.
+# Suppress R8 missing class errors so release builds can succeed without it.
+-dontwarn com.gemalto.jp2.**


### PR DESCRIPTION
## Summary
- suppress the optional JPEG2000 decoder reference from pdfbox-android so R8 can finish release builds

## Testing
- ./gradlew app:minifyReleaseWithR8 *(fails: "It is too late to set storeFilePath")*

------
https://chatgpt.com/codex/tasks/task_e_68d98292a174832ba590e8d9aba2335d