### PR TITLE
Improve asynchronous PDF loading progress

### DIFF
--- a/app/src/main/kotlin/com/novapdf/reader/PdfViewerScreen.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/PdfViewerScreen.kt
@@ -473,7 +473,10 @@ fun PdfViewerScreen(
                 }
 
                 if (state.isLoading) {
-                    LoadingOverlay(progress = state.loadingProgress)
+                    LoadingOverlay(
+                        progress = state.loadingProgress,
+                        messageRes = state.loadingMessageRes
+                    )
                 }
 
                 state.errorMessage?.let { errorMessage ->
@@ -701,7 +704,7 @@ private fun DocumentErrorDialog(
 }
 
 @Composable
-private fun LoadingOverlay(progress: Float?) {
+private fun LoadingOverlay(progress: Float?, @StringRes messageRes: Int?) {
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -714,8 +717,10 @@ private fun LoadingOverlay(progress: Float?) {
                 .fillMaxWidth(0.7f)
         ) {
             CircularProgressIndicator()
+            val message = messageRes?.let { stringResource(id = it) }
+                ?: stringResource(id = R.string.loading_document)
             Text(
-                text = stringResource(id = R.string.loading_document),
+                text = message,
                 modifier = Modifier.padding(top = 16.dp),
                 style = MaterialTheme.typography.titleMedium
             )

--- a/app/src/main/kotlin/com/novapdf/reader/ReaderActivity.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/ReaderActivity.kt
@@ -365,7 +365,9 @@ open class ReaderActivity : ComponentActivity() {
         val retry = legacyRetryButton
         when {
             state.isLoading -> {
-                statusContainer.isVisible = false
+                statusContainer.isVisible = true
+                statusText?.text = state.loadingMessageRes?.let(::getString)
+                    ?: getString(R.string.loading_document)
                 retry?.isVisible = false
             }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,6 +41,10 @@
     <string name="export_failed">Unable to export the document. Try again.</string>
     <string name="loading_document">Loading your document…</string>
     <string name="loading_progress">%1$d%% processed</string>
+    <string name="loading_stage_resolving">Preparing document…</string>
+    <string name="loading_stage_parsing">Analyzing PDF structure…</string>
+    <string name="loading_stage_rendering">Rendering the first page…</string>
+    <string name="loading_stage_finalizing">Finalizing the reader experience…</string>
     <string name="legacy_select_document">Open a PDF to start reading.</string>
     <string name="legacy_error_loading">Something went wrong while opening the PDF.</string>
     <string name="legacy_retry">Try again</string>


### PR DESCRIPTION
## Summary
- stage PDF loading updates with coroutine-backed progress reporting in the view model
- surface loading messages and progress to both Compose and legacy UIs via StateFlow
- keep initial page rendering on background threads while resetting loading state on errors

## Testing
- ./gradlew :app:testDebugUnitTest --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d9dba17544832b98dcbbd410bae75f