### PR TITLE
Handle remote PDF downloads in view model

### DIFF
--- a/app/src/main/kotlin/com/novapdf/reader/NovaPdfApp.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/NovaPdfApp.kt
@@ -9,6 +9,7 @@ import com.novapdf.reader.data.NovaPdfDatabase
 import com.novapdf.reader.data.PdfDocumentRepository
 import com.novapdf.reader.work.DocumentMaintenanceScheduler
 import com.novapdf.reader.search.LuceneSearchCoordinator
+import com.novapdf.reader.data.remote.PdfDownloadManager
 import com.tom_roush.pdfbox.android.PDFBoxResourceLoader
 
 open class NovaPdfApp : Application() {
@@ -26,6 +27,8 @@ open class NovaPdfApp : Application() {
         private set
     lateinit var searchCoordinator: LuceneSearchCoordinator
         private set
+    lateinit var pdfDownloadManager: PdfDownloadManager
+        private set
 
     override fun onCreate() {
         super.onCreate()
@@ -34,6 +37,7 @@ open class NovaPdfApp : Application() {
         pdfDocumentRepository = PdfDocumentRepository(this)
         searchCoordinator = LuceneSearchCoordinator(this, pdfDocumentRepository)
         adaptiveFlowManager = AdaptiveFlowManager(this)
+        pdfDownloadManager = PdfDownloadManager(this)
         database = Room.databaseBuilder(
             applicationContext,
             NovaPdfDatabase::class.java,

--- a/app/src/main/kotlin/com/novapdf/reader/ReaderActivity.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/ReaderActivity.kt
@@ -217,14 +217,19 @@ open class ReaderActivity : ComponentActivity() {
     }
 
     private fun openRemoteDocument(url: String) {
-        lifecycleScope.launch {
+        if (useComposeUi) {
             showUserSnackbar(getString(R.string.remote_pdf_download_started))
-            val result = downloadManager.download(url)
-            result.onSuccess { uri ->
-                viewModel.openDocument(uri)
-            }.onFailure { error ->
-                showUserSnackbar(getString(R.string.remote_pdf_download_failed))
-                viewModel.reportRemoteOpenFailure(error)
+            viewModel.openRemoteDocument(url)
+        } else {
+            lifecycleScope.launch {
+                showUserSnackbar(getString(R.string.remote_pdf_download_started))
+                val result = downloadManager.download(url)
+                result.onSuccess { uri ->
+                    viewModel.openDocument(uri)
+                }.onFailure { error ->
+                    showUserSnackbar(getString(R.string.remote_pdf_download_failed))
+                    viewModel.reportRemoteOpenFailure(error)
+                }
             }
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -45,6 +45,7 @@
     <string name="loading_stage_parsing">Analyzing PDF structure…</string>
     <string name="loading_stage_rendering">Rendering the first page…</string>
     <string name="loading_stage_finalizing">Finalizing the reader experience…</string>
+    <string name="loading_stage_downloading">Downloading PDF…</string>
     <string name="legacy_select_document">Open a PDF to start reading.</string>
     <string name="legacy_error_loading">Something went wrong while opening the PDF.</string>
     <string name="legacy_retry">Try again</string>


### PR DESCRIPTION
## Summary
- provide a shared PdfDownloadManager from NovaPdfApp so it can be reused outside the activity
- move remote download flow into PdfViewerViewModel with background loading and a dedicated "Downloading" loading stage
- let ReaderActivity delegate remote downloads to the view model when using the Compose UI and cover the new flow with unit tests

## Testing
- `./gradlew test` *(fails: Baseline Profile Gradle plugin cannot set storeFilePath after configuration when run under AGP 8.5.0)*

------
https://chatgpt.com/codex/tasks/task_e_68d9f4a7eb48832b8aa5499a8cac0f83