### PR TITLE
Fix PdfViewerViewModelSearchTest download manager mocks

### DIFF
--- a/app/src/test/kotlin/com/novapdf/reader/PdfViewerViewModelSearchTest.kt
+++ b/app/src/test/kotlin/com/novapdf/reader/PdfViewerViewModelSearchTest.kt
@@ -64,9 +64,6 @@ class PdfViewerViewModelSearchTest {
         val maintenanceScheduler = mock<DocumentMaintenanceScheduler>()
         val searchCoordinator = mock<LuceneSearchCoordinator>()
         val downloadManager = mock<PdfDownloadManager>()
-        val downloadManager = mock<PdfDownloadManager>()
-        val downloadManager = mock<PdfDownloadManager>()
-        val downloadManager = mock<PdfDownloadManager>()
 
         whenever(adaptiveFlowManager.readingSpeedPagesPerMinute).thenReturn(MutableStateFlow(30f))
         whenever(adaptiveFlowManager.swipeSensitivity).thenReturn(MutableStateFlow(1f))
@@ -120,6 +117,7 @@ class PdfViewerViewModelSearchTest {
         val bookmarkManager = mock<BookmarkManager>()
         val maintenanceScheduler = mock<DocumentMaintenanceScheduler>()
         val searchCoordinator = mock<LuceneSearchCoordinator>()
+        val downloadManager = mock<PdfDownloadManager>()
 
         whenever(adaptiveFlowManager.readingSpeedPagesPerMinute).thenReturn(MutableStateFlow(30f))
         whenever(adaptiveFlowManager.swipeSensitivity).thenReturn(MutableStateFlow(1f))
@@ -176,6 +174,7 @@ class PdfViewerViewModelSearchTest {
         val bookmarkManager = mock<BookmarkManager>()
         val maintenanceScheduler = mock<DocumentMaintenanceScheduler>()
         val searchCoordinator = mock<LuceneSearchCoordinator>()
+        val downloadManager = mock<PdfDownloadManager>()
 
         whenever(adaptiveFlowManager.readingSpeedPagesPerMinute).thenReturn(MutableStateFlow(30f))
         whenever(adaptiveFlowManager.swipeSensitivity).thenReturn(MutableStateFlow(1f))


### PR DESCRIPTION
## Summary
- remove the duplicate download manager declarations in PdfViewerViewModelSearchTest
- add the missing download manager mocks so every test can install dependencies successfully

## Testing
- ./gradlew testDebugUnitTest --info

------
https://chatgpt.com/codex/tasks/task_e_68d9f8766578832b8679a7ee469a6383