### PR TITLE
Optimize PdfViewer state updates

### DIFF
--- a/app/src/main/kotlin/com/novapdf/reader/PdfViewerViewModel.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/PdfViewerViewModel.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import com.novapdf.reader.work.DocumentMaintenanceScheduler
@@ -235,10 +236,8 @@ open class PdfViewerViewModel(
         )
     }
 
-    private suspend fun updateUiState(transform: (PdfViewerUiState) -> PdfViewerUiState) {
-        withContext(Dispatchers.Main) {
-            _uiState.value = transform(_uiState.value)
-        }
+    private fun updateUiState(transform: (PdfViewerUiState) -> PdfViewerUiState) {
+        _uiState.update(transform)
     }
 
     private suspend fun handleDocumentError(throwable: Throwable) {


### PR DESCRIPTION
## Summary
- update `PdfViewerViewModel` to mutate the `StateFlow` atomically with `MutableStateFlow.update`
- avoid main thread hopping for progress state mutations so background PDF work stays responsive

## Testing
- ./gradlew testDebugUnitTest --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68da0a4d5bec832ba47dd34de5a533d9