### PR TITLE
Keep PDF work off the main thread

### DIFF
--- a/app/src/main/kotlin/com/novapdf/reader/PdfViewerViewModel.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/PdfViewerViewModel.kt
@@ -92,15 +92,13 @@ open class PdfViewerViewModel(
         @StringRes messageRes: Int?,
         resetError: Boolean = false
     ) {
-        withContext(Dispatchers.Main.immediate) {
-            updateUiState { current ->
-                current.copy(
-                    isLoading = isLoading,
-                    loadingProgress = progress,
-                    loadingMessageRes = messageRes,
-                    errorMessage = if (resetError) null else current.errorMessage
-                )
-            }
+        updateUiState { current ->
+            current.copy(
+                isLoading = isLoading,
+                loadingProgress = progress,
+                loadingMessageRes = messageRes,
+                errorMessage = if (resetError) null else current.errorMessage
+            )
         }
     }
 
@@ -154,7 +152,7 @@ open class PdfViewerViewModel(
 
     fun openRemoteDocument(url: String) {
         val previousJob = remoteDownloadJob
-        val newJob = viewModelScope.launch {
+        val newJob = viewModelScope.launch(Dispatchers.IO) {
             previousJob?.cancelAndJoin()
             setLoadingState(
                 isLoading = true,
@@ -178,9 +176,7 @@ open class PdfViewerViewModel(
                 return@launch
             }
             result.onSuccess { uri ->
-                withContext(Dispatchers.IO) {
-                    loadDocument(uri, resetError = false)
-                }
+                loadDocument(uri, resetError = false)
             }.onFailure { throwable ->
                 if (throwable is CancellationException) {
                     setLoadingState(

--- a/app/src/main/kotlin/com/novapdf/reader/data/remote/PdfDownloadDecoder.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/data/remote/PdfDownloadDecoder.kt
@@ -12,13 +12,15 @@ import coil3.request.Options
 import java.io.File
 import okio.buffer
 import okio.sink
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 internal class PdfDownloadDecoder(
     private val fetchResult: SourceFetchResult,
     private val payload: Payload,
 ) : Decoder {
 
-    override suspend fun decode(): DecodeResult? {
+    override suspend fun decode(): DecodeResult? = withContext(Dispatchers.IO) {
         val destination = payload.destination
         val imageSource = fetchResult.source
         try {
@@ -37,7 +39,7 @@ internal class PdfDownloadDecoder(
         val placeholder = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888).apply {
             eraseColor(Color.TRANSPARENT)
         }
-        return DecodeResult(
+        DecodeResult(
             image = placeholder.asImage(),
             isSampled = true,
         )

--- a/app/src/main/kotlin/com/novapdf/reader/legacy/LegacyPdfPageAdapter.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/legacy/LegacyPdfPageAdapter.kt
@@ -89,7 +89,7 @@ class LegacyPdfPageAdapter(
         }
         holder.showLoading()
         pageJobs[pageIndex]?.cancel()
-        val job = scope.launch {
+        val job = scope.launch(Dispatchers.IO) {
             val bitmap = renderPageBitmap(pageIndex)
             withContext(Dispatchers.Main) {
                 if (holder.boundPage == pageIndex) {


### PR DESCRIPTION
## Summary
- update loading state updates to flow directly from background coroutines and move remote download work onto Dispatchers.IO
- force the custom PDF decoder to run on Dispatchers.IO so file writes never happen on the main thread
- start legacy page rendering jobs on Dispatchers.IO to keep PDF rendering off the UI thread

## Testing
- ./gradlew test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68da190815d4832bb2875a07f2f2cef8