### PR TITLE
Add render progress flow and guard PDF rendering threads

### DIFF
--- a/app/src/main/kotlin/com/novapdf/reader/PdfViewerViewModel.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/PdfViewerViewModel.kt
@@ -21,6 +21,7 @@ import com.novapdf.reader.data.PdfOpenException
 import com.novapdf.reader.R
 import com.novapdf.reader.model.AnnotationCommand
 import com.novapdf.reader.model.PdfOutlineNode
+import com.novapdf.reader.model.PdfRenderProgress
 import com.novapdf.reader.model.SearchResult
 import com.novapdf.reader.search.LuceneSearchCoordinator
 import com.novapdf.reader.data.remote.PdfDownloadManager
@@ -57,14 +58,16 @@ data class PdfViewerUiState(
     val talkBackIntegrationEnabled: Boolean = false,
     val fontScale: Float = 1f,
     val themeSeedColor: Long = DEFAULT_THEME_SEED_COLOR,
-    val outline: List<PdfOutlineNode> = emptyList()
+    val outline: List<PdfOutlineNode> = emptyList(),
+    val renderProgress: PdfRenderProgress = PdfRenderProgress.Idle
 )
 
 private data class DocumentContext(
     val speed: Float,
     val sensitivity: Float,
     val session: PdfDocumentSession?,
-    val outline: List<PdfOutlineNode>
+    val outline: List<PdfOutlineNode>,
+    val renderProgress: PdfRenderProgress
 )
 
 open class PdfViewerViewModel(
@@ -113,9 +116,10 @@ open class PdfViewerViewModel(
                 adaptiveFlowManager.readingSpeedPagesPerMinute,
                 adaptiveFlowManager.swipeSensitivity,
                 pdfRepository.session,
-                pdfRepository.outline
-            ) { speed, sensitivity, session, outline ->
-                DocumentContext(speed, sensitivity, session, outline)
+                pdfRepository.outline,
+                pdfRepository.renderProgress
+            ) { speed, sensitivity, session, outline, renderProgress ->
+                DocumentContext(speed, sensitivity, session, outline, renderProgress)
             }.collect { context ->
                 val session = context.session
                 val annotations = session?.let { annotationRepository.annotationsForDocument(it.documentId) }
@@ -128,7 +132,8 @@ open class PdfViewerViewModel(
                     pageCount = session?.pageCount ?: 0,
                     activeAnnotations = annotations,
                     bookmarks = bookmarks,
-                    outline = context.outline
+                    outline = context.outline,
+                    renderProgress = context.renderProgress
                 )
             }
         }

--- a/app/src/main/kotlin/com/novapdf/reader/model/PdfRenderProgress.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/model/PdfRenderProgress.kt
@@ -1,0 +1,6 @@
+package com.novapdf.reader.model
+
+sealed interface PdfRenderProgress {
+    object Idle : PdfRenderProgress
+    data class Rendering(val pageIndex: Int, val progress: Float) : PdfRenderProgress
+}

--- a/app/src/test/kotlin/com/novapdf/reader/PdfViewerViewModelSearchTest.kt
+++ b/app/src/test/kotlin/com/novapdf/reader/PdfViewerViewModelSearchTest.kt
@@ -8,6 +8,7 @@ import com.novapdf.reader.data.AnnotationRepository
 import com.novapdf.reader.data.BookmarkManager
 import com.novapdf.reader.data.PdfDocumentRepository
 import com.novapdf.reader.data.PdfDocumentSession
+import com.novapdf.reader.model.PdfRenderProgress
 import com.novapdf.reader.model.RectSnapshot
 import com.novapdf.reader.model.SearchMatch
 import com.novapdf.reader.model.SearchResult
@@ -183,6 +184,7 @@ class PdfViewerViewModelSearchTest {
         whenever(annotationRepository.annotationsForDocument(any())).thenReturn(emptyList())
         whenever(bookmarkManager.bookmarks(any())).thenReturn(emptyList())
         whenever(pdfRepository.outline).thenReturn(MutableStateFlow(emptyList()))
+        whenever(pdfRepository.renderProgress).thenReturn(MutableStateFlow(PdfRenderProgress.Idle))
 
         val session = PdfDocumentSession(
             documentId = "doc",
@@ -232,6 +234,7 @@ class PdfViewerViewModelSearchTest {
         whenever(annotationRepository.annotationsForDocument(any())).thenReturn(emptyList())
         whenever(bookmarkManager.bookmarks(any())).thenReturn(emptyList())
         whenever(pdfRepository.outline).thenReturn(MutableStateFlow(emptyList()))
+        whenever(pdfRepository.renderProgress).thenReturn(MutableStateFlow(PdfRenderProgress.Idle))
 
         val session = PdfDocumentSession(
             documentId = "remote_doc",
@@ -286,6 +289,7 @@ class PdfViewerViewModelSearchTest {
         whenever(annotationRepository.annotationsForDocument(any())).thenReturn(emptyList())
         whenever(bookmarkManager.bookmarks(any())).thenReturn(emptyList())
         whenever(pdfRepository.outline).thenReturn(MutableStateFlow(emptyList()))
+        whenever(pdfRepository.renderProgress).thenReturn(MutableStateFlow(PdfRenderProgress.Idle))
         whenever(pdfRepository.session).thenReturn(MutableStateFlow<PdfDocumentSession?>(null))
 
         val failingUrl = "https://example.com/bad.pdf"
@@ -332,6 +336,7 @@ class PdfViewerViewModelSearchTest {
         whenever(annotationRepository.annotationsForDocument(any())).thenReturn(emptyList())
         whenever(bookmarkManager.bookmarks(any())).thenReturn(emptyList())
         whenever(pdfRepository.outline).thenReturn(MutableStateFlow(emptyList()))
+        whenever(pdfRepository.renderProgress).thenReturn(MutableStateFlow(PdfRenderProgress.Idle))
         whenever(pdfRepository.session).thenReturn(MutableStateFlow<PdfDocumentSession?>(null))
 
         val failingUrl = "https://example.com/bad.pdf"
@@ -378,6 +383,7 @@ class PdfViewerViewModelSearchTest {
         whenever(annotationRepository.annotationsForDocument(any())).thenReturn(emptyList())
         whenever(bookmarkManager.bookmarks(any())).thenReturn(emptyList())
         whenever(pdfRepository.outline).thenReturn(MutableStateFlow(emptyList()))
+        whenever(pdfRepository.renderProgress).thenReturn(MutableStateFlow(PdfRenderProgress.Idle))
         whenever(pdfRepository.session).thenReturn(MutableStateFlow<PdfDocumentSession?>(null))
 
         val url = "https://example.com/cancel.pdf"


### PR DESCRIPTION
## Summary
- add a PdfRenderProgress model and expose a renderProgress StateFlow from PdfDocumentRepository
- guard PDF decode/render work against the main thread and emit rendering progress updates
- propagate the render progress state through PdfViewerViewModel and update the search tests

## Testing
- ./gradlew :app:testDebugUnitTest --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68da1cbaeda8832bbd6133464129eb70