### PR TITLE
Add worker thread annotations and verify render progress propagation

### DIFF
--- a/app/src/test/kotlin/com/novapdf/reader/PdfViewerViewModelRenderProgressTest.kt
+++ b/app/src/test/kotlin/com/novapdf/reader/PdfViewerViewModelRenderProgressTest.kt
@@ -1,0 +1,91 @@
+package com.novapdf.reader
+
+import com.novapdf.reader.data.AnnotationRepository
+import com.novapdf.reader.data.BookmarkManager
+import com.novapdf.reader.data.PdfDocumentRepository
+import com.novapdf.reader.data.PdfDocumentSession
+import com.novapdf.reader.data.remote.PdfDownloadManager
+import com.novapdf.reader.model.PdfRenderProgress
+import com.novapdf.reader.model.PdfOutlineNode
+import com.novapdf.reader.search.LuceneSearchCoordinator
+import com.novapdf.reader.work.DocumentMaintenanceScheduler
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class PdfViewerViewModelRenderProgressTest {
+
+    private val dispatcher = UnconfinedTestDispatcher()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    @Config(application = TestPdfApp::class)
+    fun `uiState mirrors repository render progress`() = runTest {
+        val annotationRepository = mock<AnnotationRepository>()
+        val pdfRepository = mock<PdfDocumentRepository>()
+        val adaptiveFlowManager = mock<AdaptiveFlowManager>()
+        val bookmarkManager = mock<BookmarkManager>()
+        val maintenanceScheduler = mock<DocumentMaintenanceScheduler>()
+        val searchCoordinator = mock<LuceneSearchCoordinator>()
+        val downloadManager = mock<PdfDownloadManager>()
+
+        val renderProgress = MutableStateFlow<PdfRenderProgress>(PdfRenderProgress.Idle)
+        whenever(pdfRepository.renderProgress).thenReturn(renderProgress)
+        whenever(pdfRepository.session).thenReturn(MutableStateFlow<PdfDocumentSession?>(null))
+        whenever(pdfRepository.outline).thenReturn(MutableStateFlow<List<PdfOutlineNode>>(emptyList()))
+
+        whenever(annotationRepository.annotationsForDocument(any())).thenReturn(emptyList())
+        whenever(bookmarkManager.bookmarks(any())).thenReturn(emptyList())
+
+        whenever(adaptiveFlowManager.readingSpeedPagesPerMinute).thenReturn(MutableStateFlow(30f))
+        whenever(adaptiveFlowManager.swipeSensitivity).thenReturn(MutableStateFlow(1f))
+        whenever(adaptiveFlowManager.preloadTargets).thenReturn(MutableStateFlow(emptyList()))
+
+        val app = TestPdfApp.getInstance()
+        app.installDependencies(
+            annotationRepository,
+            pdfRepository,
+            adaptiveFlowManager,
+            bookmarkManager,
+            maintenanceScheduler,
+            searchCoordinator,
+            downloadManager
+        )
+
+        val viewModel = PdfViewerViewModel(app)
+
+        renderProgress.value = PdfRenderProgress.Rendering(pageIndex = 2, progress = 0.4f)
+        advanceUntilIdle()
+        assertEquals(PdfRenderProgress.Rendering(2, 0.4f), viewModel.uiState.value.renderProgress)
+
+        renderProgress.value = PdfRenderProgress.Idle
+        advanceUntilIdle()
+        assertEquals(PdfRenderProgress.Idle, viewModel.uiState.value.renderProgress)
+    }
+}

--- a/app/src/test/kotlin/com/novapdf/reader/PdfViewerViewModelSearchTest.kt
+++ b/app/src/test/kotlin/com/novapdf/reader/PdfViewerViewModelSearchTest.kt
@@ -3,7 +3,6 @@ package com.novapdf.reader
 import android.graphics.Bitmap
 import android.net.Uri
 import android.os.ParcelFileDescriptor
-import androidx.test.core.app.ApplicationProvider
 import com.novapdf.reader.data.AnnotationRepository
 import com.novapdf.reader.data.BookmarkManager
 import com.novapdf.reader.data.PdfDocumentRepository
@@ -411,39 +410,4 @@ class PdfViewerViewModelSearchTest {
         assertEquals(null, uiState.loadingMessageRes)
     }
 
-    class TestPdfApp : NovaPdfApp() {
-        override fun onCreate() {
-            // Skip default initialisation to allow tests to inject fakes.
-        }
-
-        fun installDependencies(
-            annotationRepository: AnnotationRepository,
-            pdfRepository: PdfDocumentRepository,
-            adaptiveFlowManager: AdaptiveFlowManager,
-            bookmarkManager: BookmarkManager,
-            documentMaintenanceScheduler: DocumentMaintenanceScheduler,
-            searchCoordinator: LuceneSearchCoordinator,
-            pdfDownloadManager: PdfDownloadManager
-        ) {
-            setField("annotationRepository", annotationRepository)
-            setField("pdfDocumentRepository", pdfRepository)
-            setField("adaptiveFlowManager", adaptiveFlowManager)
-            setField("bookmarkManager", bookmarkManager)
-            setField("documentMaintenanceScheduler", documentMaintenanceScheduler)
-            setField("searchCoordinator", searchCoordinator)
-            setField("pdfDownloadManager", pdfDownloadManager)
-        }
-
-        private fun setField(name: String, value: Any) {
-            val field = NovaPdfApp::class.java.getDeclaredField(name)
-            field.isAccessible = true
-            field.set(this, value)
-        }
-
-        companion object {
-            fun getInstance(): TestPdfApp {
-                return ApplicationProvider.getApplicationContext()
-            }
-        }
-    }
 }

--- a/app/src/test/kotlin/com/novapdf/reader/TestPdfApp.kt
+++ b/app/src/test/kotlin/com/novapdf/reader/TestPdfApp.kt
@@ -1,0 +1,46 @@
+package com.novapdf.reader
+
+import androidx.test.core.app.ApplicationProvider
+import com.novapdf.reader.AdaptiveFlowManager
+import com.novapdf.reader.data.AnnotationRepository
+import com.novapdf.reader.data.BookmarkManager
+import com.novapdf.reader.data.PdfDocumentRepository
+import com.novapdf.reader.data.remote.PdfDownloadManager
+import com.novapdf.reader.search.LuceneSearchCoordinator
+import com.novapdf.reader.work.DocumentMaintenanceScheduler
+
+class TestPdfApp : NovaPdfApp() {
+    override fun onCreate() {
+        // Skip default initialization so tests can inject dependencies explicitly.
+    }
+
+    fun installDependencies(
+        annotationRepository: AnnotationRepository,
+        pdfRepository: PdfDocumentRepository,
+        adaptiveFlowManager: AdaptiveFlowManager,
+        bookmarkManager: BookmarkManager,
+        documentMaintenanceScheduler: DocumentMaintenanceScheduler,
+        searchCoordinator: LuceneSearchCoordinator,
+        pdfDownloadManager: PdfDownloadManager,
+    ) {
+        setField("annotationRepository", annotationRepository)
+        setField("pdfDocumentRepository", pdfRepository)
+        setField("adaptiveFlowManager", adaptiveFlowManager)
+        setField("bookmarkManager", bookmarkManager)
+        setField("documentMaintenanceScheduler", documentMaintenanceScheduler)
+        setField("searchCoordinator", searchCoordinator)
+        setField("pdfDownloadManager", pdfDownloadManager)
+    }
+
+    private fun setField(name: String, value: Any) {
+        val field = NovaPdfApp::class.java.getDeclaredField(name)
+        field.isAccessible = true
+        field.set(this, value)
+    }
+
+    companion object {
+        fun getInstance(): TestPdfApp {
+            return ApplicationProvider.getApplicationContext()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- annotate PdfDocumentRepository's PDF operations with @WorkerThread to document and enforce off-main usage
- extract a reusable TestPdfApp fixture for injecting test dependencies and add a render progress propagation test for PdfViewerViewModel

## Testing
- ./gradlew --no-daemon --console=plain test

------
https://chatgpt.com/codex/tasks/task_e_68da37c38690832b8c4e8eed200021f1