### PR TITLE
Reset Compose viewer status overlays on failure

### DIFF
--- a/app/src/main/kotlin/com/novapdf/reader/PdfViewerScreen.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/PdfViewerScreen.kt
@@ -481,7 +481,7 @@ fun PdfViewerScreen(
                 }
 
                 val renderProgressState = state.renderProgress
-                if (state.documentStatus !is DocumentStatus.Loading &&
+                if (state.documentStatus is DocumentStatus.Idle &&
                     renderProgressState is PdfRenderProgress.Rendering
                 ) {
                     RenderProgressIndicator(

--- a/app/src/main/kotlin/com/novapdf/reader/PdfViewerViewModel.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/PdfViewerViewModel.kt
@@ -113,6 +113,16 @@ open class PdfViewerViewModel(
         }
     }
 
+    private fun resetTransientStatus() {
+        updateUiState { current ->
+            when (current.documentStatus) {
+                is DocumentStatus.Loading,
+                is DocumentStatus.Error -> current.copy(documentStatus = DocumentStatus.Idle)
+                DocumentStatus.Idle -> current
+            }
+        }
+    }
+
     init {
         val supportsDynamicColor = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
         _uiState.value = _uiState.value.copy(
@@ -288,6 +298,7 @@ open class PdfViewerViewModel(
     }
 
     private suspend fun handleDocumentError(throwable: Throwable) {
+        resetTransientStatus()
         val message = when (throwable) {
             is PdfOpenException -> when (throwable.reason) {
                 PdfOpenException.Reason.CORRUPTED -> app.getString(R.string.error_pdf_corrupted)
@@ -301,6 +312,7 @@ open class PdfViewerViewModel(
 
     fun reportRemoteOpenFailure(@Suppress("UNUSED_PARAMETER") throwable: Throwable) {
         viewModelScope.launch {
+            resetTransientStatus()
             showError(app.getString(R.string.error_remote_open_failed))
         }
     }


### PR DESCRIPTION
## Summary
- add a helper that clears transient document status before posting Compose error overlays so loading progress resets on failure
- gate the render progress indicator on idle status to avoid overlapping with loading or error surfaces

## Testing
- ./gradlew :app:lint --console=plain *(fails: existing NewApi lint violation in ReaderActivity.kt)*

------
https://chatgpt.com/codex/tasks/task_e_68da4b78a780832bb7641f6616ce9a86