### PR TITLE
Add stress PDF instrumentation coverage and logcat validation

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -334,7 +334,21 @@ jobs:
           adb shell settings put global animator_duration_scale 0 || true
           adb shell input keyevent 82 || true
       - name: Run instrumentation tests
-        run: ./gradlew connectedAndroidTest --stacktrace
+        run: |
+          adb logcat -c || true
+          ./gradlew connectedAndroidTest --stacktrace
+      - name: Validate ANR and crash-free logcat
+        run: |
+          set -euo pipefail
+          adb logcat -d > logcat-after-tests.txt
+          if grep -E "ANR in com\.novapdf\.reader" logcat-after-tests.txt; then
+            echo "::error::Detected Application Not Responding dialog for com.novapdf.reader during instrumentation tests"
+            exit 1
+          fi
+          if grep -E "FATAL EXCEPTION: .*Process: com\.novapdf\.reader" logcat-after-tests.txt; then
+            echo "::error::Detected fatal crash in com.novapdf.reader during instrumentation tests"
+            exit 1
+          fi
       - name: Install debug build for screenshots
         run: |
           set -euo pipefail

--- a/README.md
+++ b/README.md
@@ -43,6 +43,16 @@ the `platform-tools`, `build-tools`, and emulator components for API level 35.
 When no device is present, the build gracefully skips connected tests while still verifying
 that the project compiles.
 
+## CI validation for heavy PDF workloads
+
+Continuous integration now provisions a synthetic stress PDF with 32 pages that mix large,
+panoramic, and extreme aspect ratios to exercise Pdfium rendering paths. Instrumentation
+tests open and render multiple locations within the document to ensure the viewer can
+handle atypical source material, while the workflow fails fast if logcat reports an
+Application Not Responding dialog or a fatal crash for `com.novapdf.reader`. To reproduce
+the checks locally, run `./gradlew connectedAndroidTest` on an emulator or device and
+inspect `adb logcat` for `ANR in com.novapdf.reader` or fatal exception entries.
+
 ## Gradle wrapper bootstrap
 
 Binary assets such as the `gradle-wrapper.jar` are intentionally not stored in this repository. Instead, the wrapper JAR is stored as a Base64 text file at `gradle/wrapper/gradle-wrapper.jar.base64`. The included `gradlew` and `gradlew.bat` scripts automatically decode this archive to `gradle/wrapper/gradle-wrapper.jar` (Gradle 8.5) the first time you run them.

--- a/app/src/androidTest/kotlin/com/novapdf/reader/LargePdfInstrumentedTest.kt
+++ b/app/src/androidTest/kotlin/com/novapdf/reader/LargePdfInstrumentedTest.kt
@@ -1,0 +1,50 @@
+package com.novapdf.reader
+
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.novapdf.reader.data.PdfDocumentRepository
+import java.io.File
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class LargePdfInstrumentedTest {
+
+    @Test
+    fun openLargeAndUnusualDocumentWithoutAnrOrCrash() = runBlocking {
+        val context = ApplicationProvider.getApplicationContext<NovaPdfApp>()
+        val repository = PdfDocumentRepository(context)
+        try {
+            val stressUri = StressDocumentFactory.installStressDocument(context)
+            val session = withTimeout(60_000) { repository.open(stressUri) }
+            assertNotNull("Stress PDF should open successfully", session)
+            val pdfSession = requireNotNull(session)
+            assertEquals(32, pdfSession.pageCount)
+
+            val sampleIndices = linkedSetOf(0, pdfSession.pageCount / 2, pdfSession.pageCount - 1)
+            for (index in sampleIndices) {
+                val pageSize = withTimeout(30_000) { repository.getPageSize(index) }
+                assertNotNull("Page $index should report a size", pageSize)
+                val size = requireNotNull(pageSize)
+                assertTrue("Page width should be > 0", size.width > 0)
+                assertTrue("Page height should be > 0", size.height > 0)
+
+                val renderWidth = size.width.coerceAtLeast(size.height).coerceAtMost(4000)
+                val bitmap = withTimeout(60_000) { repository.renderPage(index, renderWidth) }
+                assertNotNull("Page $index should render", bitmap)
+                val renderedPage = requireNotNull(bitmap)
+                renderedPage.recycle()
+            }
+
+            val cacheDir = File(context.cacheDir, "instrumentation-screenshots").apply { mkdirs() }
+            assertTrue("Cache directory should exist", cacheDir.exists())
+        } finally {
+            repository.dispose()
+        }
+    }
+}

--- a/app/src/androidTest/kotlin/com/novapdf/reader/StressDocumentFactory.kt
+++ b/app/src/androidTest/kotlin/com/novapdf/reader/StressDocumentFactory.kt
@@ -1,0 +1,174 @@
+package com.novapdf.reader
+
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.Typeface
+import android.graphics.pdf.PdfDocument
+import androidx.core.net.toUri
+import java.io.File
+import java.io.IOException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlin.math.absoluteValue
+import kotlin.math.max
+import kotlin.math.min
+
+internal object StressDocumentFactory {
+    private const val LARGE_CACHE_FILE_NAME = "stress-large.pdf"
+    private const val PAGE_COUNT = 32
+
+    suspend fun installStressDocument(context: Context) = withContext(Dispatchers.IO) {
+        val cacheFile = File(context.cacheDir, LARGE_CACHE_FILE_NAME)
+        cacheFile.parentFile?.mkdirs()
+        if (!cacheFile.exists() || cacheFile.length() == 0L) {
+            generateStressDocument(cacheFile)
+        }
+        cacheFile.toUri()
+    }
+
+    private fun generateStressDocument(destination: File) {
+        val parentDir = destination.parentFile ?: throw IOException("Missing cache directory for stress PDF")
+        if (!parentDir.exists() && !parentDir.mkdirs()) {
+            throw IOException("Unable to create cache directory for stress PDF")
+        }
+
+        val tempFile = File(parentDir, destination.name + ".tmp")
+        if (tempFile.exists() && !tempFile.delete()) {
+            throw IOException("Unable to clear stale stress PDF cache")
+        }
+
+        val pdfDocument = PdfDocument()
+        val paint = Paint().apply {
+            color = Color.BLACK
+            textSize = 36f
+            isAntiAlias = true
+            typeface = Typeface.MONOSPACE
+        }
+
+        val backgroundPaint = Paint().apply {
+            style = Paint.Style.FILL
+        }
+
+        val pageSizes = buildList {
+            // A mix of portrait, landscape, and extreme aspect ratio pages to mimic "unusual" PDFs
+            add(PdfDocument.PageInfo.Builder(2480, 3508, 1).create()) // A4 portrait
+            add(PdfDocument.PageInfo.Builder(3508, 2480, 2).create()) // A4 landscape
+            add(PdfDocument.PageInfo.Builder(2000, 6000, 3).create()) // Tall infographic style
+            add(PdfDocument.PageInfo.Builder(6000, 2000, 4).create()) // Wide panoramic spread
+        }
+
+        try {
+            repeat(PAGE_COUNT) { index ->
+                val pageInfo = pageSizes[index % pageSizes.size]
+                val dynamicPageInfo = PdfDocument.PageInfo.Builder(
+                    pageInfo.pageWidth,
+                    pageInfo.pageHeight,
+                    index + 1
+                ).create()
+
+                val page = pdfDocument.startPage(dynamicPageInfo)
+                val canvas = page.canvas
+                drawStressContent(canvas, index, paint, backgroundPaint)
+                pdfDocument.finishPage(page)
+            }
+
+            tempFile.outputStream().use { outputStream ->
+                pdfDocument.writeTo(outputStream)
+                outputStream.flush()
+            }
+        } finally {
+            pdfDocument.close()
+        }
+
+        if (destination.exists() && !destination.delete()) {
+            tempFile.delete()
+            throw IOException("Unable to replace cached stress PDF")
+        }
+        if (!tempFile.renameTo(destination)) {
+            tempFile.delete()
+            throw IOException("Unable to move stress PDF into cache")
+        }
+    }
+
+    private fun drawStressContent(
+        canvas: Canvas,
+        pageIndex: Int,
+        paint: Paint,
+        backgroundPaint: Paint,
+    ) {
+        val pageNumber = pageIndex + 1
+        val baseColor = Color.HSVToColor(
+            floatArrayOf(((pageIndex * 47) % 360).toFloat(), 0.3f + (pageIndex % 5) * 0.1f, 0.9f)
+        )
+        backgroundPaint.color = baseColor
+        canvas.drawRect(0f, 0f, canvas.width.toFloat(), canvas.height.toFloat(), backgroundPaint)
+
+        paint.color = Color.BLACK
+        canvas.drawText(
+            "Stress document page $pageNumber/${PAGE_COUNT}",
+            64f,
+            96f,
+            paint
+        )
+
+        val gridPaint = Paint().apply {
+            color = Color.argb(96, 0, 0, 0)
+            strokeWidth = 2f
+        }
+        val gridSpacing = max(120, min(canvas.width, canvas.height) / 12)
+        var x = 0
+        while (x < canvas.width) {
+            canvas.drawLine(x.toFloat(), 0f, x.toFloat(), canvas.height.toFloat(), gridPaint)
+            x += gridSpacing
+        }
+        var y = 0
+        while (y < canvas.height) {
+            canvas.drawLine(0f, y.toFloat(), canvas.width.toFloat(), y.toFloat(), gridPaint)
+            y += gridSpacing
+        }
+
+        val accentPaint = Paint().apply {
+            style = Paint.Style.STROKE
+            strokeWidth = 6f
+            color = Color.rgb(
+                (128 + ((pageIndex * 37) % 127)).coerceIn(0, 255),
+                (64 + ((pageIndex * 53) % 191)).coerceIn(0, 255),
+                (96 + ((pageIndex * 29) % 159)).coerceIn(0, 255)
+            )
+        }
+        val margin = gridSpacing / 2f
+        val rectWidth = canvas.width - margin * 2
+        val rectHeight = canvas.height - margin * 2
+        canvas.drawRect(margin, margin, margin + rectWidth, margin + rectHeight, accentPaint)
+
+        val diagPaint = Paint().apply {
+            style = Paint.Style.STROKE
+            strokeWidth = 4f
+            color = Color.argb(160, 255, 255, 255)
+        }
+        canvas.drawLine(0f, 0f, canvas.width.toFloat(), canvas.height.toFloat(), diagPaint)
+        canvas.drawLine(
+            0f,
+            canvas.height.toFloat(),
+            canvas.width.toFloat(),
+            0f,
+            diagPaint
+        )
+
+        paint.color = Color.DKGRAY
+        val textBlock = buildString {
+            appendLine("Generated for instrumentation stress testing.")
+            appendLine("Canvas size: ${canvas.width}x${canvas.height}")
+            appendLine("Aspect ratio: %.2f".format(canvas.width.toFloat() / canvas.height.toFloat()))
+            appendLine("Checksum seed: ${(pageIndex * 31).absoluteValue}")
+        }
+        val lines = textBlock.trimEnd().split('\n')
+        var textY = canvas.height - margin * 1.5f
+        for (line in lines.asReversed()) {
+            canvas.drawText(line, margin, textY, paint)
+            textY -= paint.textSize * 1.4f
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- generate a synthetic large-and-unusual PDF fixture for instrumentation
- add instrumentation coverage that exercises the stress document to guard against ANRs and crashes
- clear logcat before connected tests, fail the workflow when ANR or fatal crash entries are detected, and document the new CI requirement

## Testing
- ./gradlew testDebugUnitTest

------
https://chatgpt.com/codex/tasks/task_e_68da53735798832b88cd0012b91c4d7a