### PR TITLE
Ensure CI validates stress PDF instrumentation

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -337,6 +337,35 @@ jobs:
         run: |
           adb logcat -c || true
           ./gradlew connectedAndroidTest --stacktrace
+      - name: Verify large PDF stress instrumentation ran
+        run: |
+          set -euo pipefail
+          results_dir="app/build/outputs/androidTest-results/connected"
+          if [ ! -d "$results_dir" ]; then
+            echo "::error::Instrumentation results directory $results_dir not found"
+            exit 1
+          fi
+
+          python3 - <<'PY'
+import pathlib
+import sys
+
+results_dir = pathlib.Path("app/build/outputs/androidTest-results/connected")
+stress_method = "openLargeAndUnusualDocumentWithoutAnrOrCrash"
+stress_class = "com.novapdf.reader.LargePdfInstrumentedTest"
+
+matched = False
+for report in results_dir.rglob("TEST-*.xml"):
+    text = report.read_text(encoding="utf-8", errors="replace")
+    if stress_method in text and stress_class in text:
+        print(f"Found stress PDF instrumentation results in {report}")
+        matched = True
+        break
+
+if not matched:
+    print("::error::LargePdfInstrumentedTest did not run during connectedAndroidTest")
+    sys.exit(1)
+PY
       - name: Validate ANR and crash-free logcat
         run: |
           set -euo pipefail

--- a/README.md
+++ b/README.md
@@ -49,9 +49,11 @@ Continuous integration now provisions a synthetic stress PDF with 32 pages that 
 panoramic, and extreme aspect ratios to exercise Pdfium rendering paths. Instrumentation
 tests open and render multiple locations within the document to ensure the viewer can
 handle atypical source material, while the workflow fails fast if logcat reports an
-Application Not Responding dialog or a fatal crash for `com.novapdf.reader`. To reproduce
-the checks locally, run `./gradlew connectedAndroidTest` on an emulator or device and
-inspect `adb logcat` for `ANR in com.novapdf.reader` or fatal exception entries.
+Application Not Responding dialog or a fatal crash for `com.novapdf.reader`. The workflow
+also verifies that the `LargePdfInstrumentedTest` suite executed so regressions cannot
+skip the heavy document coverage silently. To reproduce the checks locally, run
+`./gradlew connectedAndroidTest` on an emulator or device and inspect `adb logcat` for `ANR
+in com.novapdf.reader` or fatal exception entries.
 
 ## Gradle wrapper bootstrap
 


### PR DESCRIPTION
## Summary
- add a GitHub Actions guard that fails when the large PDF instrumentation test is skipped
- document the CI stress PDF verification so contributors know about the requirement

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68da565710cc832ba3f6a65c07cb43ce