### PR TITLE
Fix YAML indentation for Python heredoc scripts

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -347,96 +347,96 @@ jobs:
           fi
 
           python3 - <<'PY'
-import pathlib
-import sys
-import xml.etree.ElementTree as ET
+          import pathlib
+          import sys
+          import xml.etree.ElementTree as ET
 
-results_dir = pathlib.Path("app/build/outputs/androidTest-results/connected")
-stress_method = "openLargeAndUnusualDocumentWithoutAnrOrCrash"
-stress_class = "com.novapdf.reader.LargePdfInstrumentedTest"
+          results_dir = pathlib.Path("app/build/outputs/androidTest-results/connected")
+          stress_method = "openLargeAndUnusualDocumentWithoutAnrOrCrash"
+          stress_class = "com.novapdf.reader.LargePdfInstrumentedTest"
 
-matched_report = None
-for report in results_dir.rglob("TEST-*.xml"):
-    try:
-        tree = ET.parse(report)
-    except ET.ParseError as exc:
-        print(f"Skipping unreadable instrumentation report {report}: {exc}")
-        continue
+          matched_report = None
+          for report in results_dir.rglob("TEST-*.xml"):
+              try:
+                  tree = ET.parse(report)
+              except ET.ParseError as exc:
+                  print(f"Skipping unreadable instrumentation report {report}: {exc}")
+                  continue
 
-    root = tree.getroot()
-    for testcase in root.iter("testcase"):
-        if testcase.get("classname") == stress_class and testcase.get("name") == stress_method:
-            if any(child.tag in {"failure", "error"} for child in testcase):
-                print("::error::LargePdfInstrumentedTest reported a failure in", report)
-                sys.exit(1)
-            if any(child.tag == "skipped" for child in testcase) or testcase.get("status") == "skipped":
-                print("::error::LargePdfInstrumentedTest was skipped in", report)
-                sys.exit(1)
-            matched_report = report
-            break
-    if matched_report:
-        break
+              root = tree.getroot()
+              for testcase in root.iter("testcase"):
+                  if testcase.get("classname") == stress_class and testcase.get("name") == stress_method:
+                      if any(child.tag in {"failure", "error"} for child in testcase):
+                          print("::error::LargePdfInstrumentedTest reported a failure in", report)
+                          sys.exit(1)
+                      if any(child.tag == "skipped" for child in testcase) or testcase.get("status") == "skipped":
+                          print("::error::LargePdfInstrumentedTest was skipped in", report)
+                          sys.exit(1)
+                      matched_report = report
+                      break
+              if matched_report:
+                  break
 
-if matched_report is None:
-    print("::error::LargePdfInstrumentedTest did not run during connectedAndroidTest")
-    sys.exit(1)
+          if matched_report is None:
+              print("::error::LargePdfInstrumentedTest did not run during connectedAndroidTest")
+              sys.exit(1)
 
-print(f"Confirmed LargePdfInstrumentedTest execution in {matched_report}")
-PY
+          print(f"Confirmed LargePdfInstrumentedTest execution in {matched_report}")
+          PY
       - name: Validate ANR and crash-free logcat
         run: |
           set -euo pipefail
           adb logcat -d > logcat-after-tests.txt
           python3 - <<'PY'
-import pathlib
-import re
-import sys
+          import pathlib
+          import re
+          import sys
 
-log_path = pathlib.Path("logcat-after-tests.txt")
-if not log_path.exists():
-    print("::error::Unable to locate captured logcat at", log_path)
-    sys.exit(1)
+          log_path = pathlib.Path("logcat-after-tests.txt")
+          if not log_path.exists():
+              print("::error::Unable to locate captured logcat at", log_path)
+              sys.exit(1)
 
-contents = log_path.read_text(encoding="utf-8", errors="ignore")
-crash_signatures = [
-    (
-        re.compile(r"ANR in com\\.novapdf\\.reader"),
-        "Detected Application Not Responding dialog for com.novapdf.reader during instrumentation tests",
-    ),
-    (
-        re.compile(r"Application is not responding: Process com\\.novapdf\\.reader"),
-        "Detected system level 'Application is not responding' warning for com.novapdf.reader",
-    ),
-    (
-        re.compile(r"FATAL EXCEPTION: .*Process: com\\.novapdf\\.reader"),
-        "Detected fatal crash in com.novapdf.reader during instrumentation tests",
-    ),
-    (
-        re.compile(r"E AndroidRuntime: FATAL EXCEPTION"),
-        "AndroidRuntime reported a fatal exception while instrumentation tests were running",
-    ),
-    (
-        re.compile(r"Fatal signal \d+ .*? \(SIG[A-Z]+\).*?com\\.novapdf\\.reader"),
-        "Detected native crash (fatal signal) for com.novapdf.reader during instrumentation tests",
-    ),
-    (
-        re.compile(r"Process com\\.novapdf\\.reader has died"),
-        "System server logged that com.novapdf.reader process died during instrumentation tests",
-    ),
-    (
-        re.compile(r"Force finishing activity com\\.novapdf\\.reader"),
-        "Activity manager force-finished NovaPDF Reader during instrumentation tests",
-    ),
-]
+          contents = log_path.read_text(encoding="utf-8", errors="ignore")
+          crash_signatures = [
+              (
+                  re.compile(r"ANR in com\\.novapdf\\.reader"),
+                  "Detected Application Not Responding dialog for com.novapdf.reader during instrumentation tests",
+              ),
+              (
+                  re.compile(r"Application is not responding: Process com\\.novapdf\\.reader"),
+                  "Detected system level 'Application is not responding' warning for com.novapdf.reader",
+              ),
+              (
+                  re.compile(r"FATAL EXCEPTION: .*Process: com\\.novapdf\\.reader"),
+                  "Detected fatal crash in com.novapdf.reader during instrumentation tests",
+              ),
+              (
+                  re.compile(r"E AndroidRuntime: FATAL EXCEPTION"),
+                  "AndroidRuntime reported a fatal exception while instrumentation tests were running",
+              ),
+              (
+                  re.compile(r"Fatal signal \d+ .*? \(SIG[A-Z]+\).*?com\\.novapdf\\.reader"),
+                  "Detected native crash (fatal signal) for com.novapdf.reader during instrumentation tests",
+              ),
+              (
+                  re.compile(r"Process com\\.novapdf\\.reader has died"),
+                  "System server logged that com.novapdf.reader process died during instrumentation tests",
+              ),
+              (
+                  re.compile(r"Force finishing activity com\\.novapdf\\.reader"),
+                  "Activity manager force-finished NovaPDF Reader during instrumentation tests",
+              ),
+          ]
 
-issues = [message for pattern, message in crash_signatures if pattern.search(contents)]
-if issues:
-    for message in issues:
-        print(f"::error::{message}")
-    sys.exit(1)
+          issues = [message for pattern, message in crash_signatures if pattern.search(contents)]
+          if issues:
+              for message in issues:
+                  print(f"::error::{message}")
+              sys.exit(1)
 
-print("Logcat is free from ANR/crash signatures")
-PY
+          print("Logcat is free from ANR/crash signatures")
+          PY
       - name: Install debug build for screenshots
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary
- indent Python here-doc scripts inside the instrumentation validation steps so the YAML workflow parses correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da5b655194832bb0d65952f12b9167