### PR TITLE
Ensure CI validates heavy PDF instrumentation coverage

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -337,7 +337,7 @@ jobs:
         run: |
           adb logcat -c || true
           ./gradlew connectedAndroidTest --stacktrace
-      - name: Verify large PDF stress instrumentation ran
+      - name: Verify heavy PDF instrumentation coverage
         run: |
           set -euo pipefail
           results_dir="app/build/outputs/androidTest-results/connected"
@@ -352,10 +352,19 @@ jobs:
           import xml.etree.ElementTree as ET
 
           results_dir = pathlib.Path("app/build/outputs/androidTest-results/connected")
-          stress_method = "openLargeAndUnusualDocumentWithoutAnrOrCrash"
-          stress_class = "com.novapdf.reader.LargePdfInstrumentedTest"
+          required_tests = {
+              (
+                  "com.novapdf.reader.LargePdfInstrumentedTest",
+                  "openLargeAndUnusualDocumentWithoutAnrOrCrash",
+              ),
+              (
+                  "com.novapdf.reader.PdfViewerUiAutomatorTest",
+                  "loadsThousandPageDocumentAndActivatesAdaptiveFlow",
+              ),
+          }
 
-          matched_report = None
+          executed_tests = {}
+
           for report in results_dir.rglob("TEST-*.xml"):
               try:
                   tree = ET.parse(report)
@@ -365,23 +374,34 @@ jobs:
 
               root = tree.getroot()
               for testcase in root.iter("testcase"):
-                  if testcase.get("classname") == stress_class and testcase.get("name") == stress_method:
-                      if any(child.tag in {"failure", "error"} for child in testcase):
-                          print("::error::LargePdfInstrumentedTest reported a failure in", report)
-                          sys.exit(1)
-                      if any(child.tag == "skipped" for child in testcase) or testcase.get("status") == "skipped":
-                          print("::error::LargePdfInstrumentedTest was skipped in", report)
-                          sys.exit(1)
-                      matched_report = report
-                      break
-              if matched_report:
-                  break
+                  key = (testcase.get("classname"), testcase.get("name"))
+                  if key not in required_tests:
+                      continue
 
-          if matched_report is None:
-              print("::error::LargePdfInstrumentedTest did not run during connectedAndroidTest")
+                  if any(child.tag in {"failure", "error"} for child in testcase):
+                      print(
+                          f"::error::Required instrumentation test {key[0]}.{key[1]} failed in {report}"
+                      )
+                      sys.exit(1)
+
+                  if any(child.tag == "skipped" for child in testcase) or testcase.get("status") == "skipped":
+                      print(
+                          f"::error::Required instrumentation test {key[0]}.{key[1]} was skipped in {report}"
+                      )
+                      sys.exit(1)
+
+                  executed_tests.setdefault(key, report)
+
+          missing = required_tests.difference(executed_tests.keys())
+          if missing:
+              missing_descriptions = ", ".join(f"{cls}.{name}" for cls, name in sorted(missing))
+              print(
+                  f"::error::Connected Android tests did not execute required instrumentation coverage for: {missing_descriptions}"
+              )
               sys.exit(1)
 
-          print(f"Confirmed LargePdfInstrumentedTest execution in {matched_report}")
+          for key, report in sorted(executed_tests.items()):
+              print(f"Confirmed {key[0]}.{key[1]} execution in {report}")
           PY
       - name: Validate ANR and crash-free logcat
         run: |

--- a/README.md
+++ b/README.md
@@ -47,16 +47,16 @@ that the project compiles.
 
 Continuous integration now provisions a synthetic stress PDF with 32 pages that mix large,
 panoramic, and extreme aspect ratios to exercise Pdfium rendering paths. Instrumentation
-tests now open portrait, landscape, tall infographic, and ultra-wide panorama variants of
-the document to ensure the viewer can handle atypical source material. The workflow also
-fails fast if logcat reports an
-Application Not Responding dialog, fatal Java exception, fatal signal, or forced process
-restart for `com.novapdf.reader`. The workflow
-verifies that the `LargePdfInstrumentedTest` suite executed without being skipped so
-regressions cannot silently avoid the heavy document coverage. To reproduce the checks
-locally, run
-`./gradlew connectedAndroidTest` on an emulator or device and inspect `adb logcat` for `ANR
-in com.novapdf.reader` or fatal exception entries.
+tests open portrait, landscape, tall infographic, and ultra-wide panorama variants of the
+document and drive a thousand-page fixture through the UI to ensure the viewer can handle
+atypical source material. The workflow fails fast if logcat reports an Application Not
+Responding dialog, fatal Java exception, fatal signal, or forced process restart for
+`com.novapdf.reader`. It also verifies that both the
+`LargePdfInstrumentedTest.openLargeAndUnusualDocumentWithoutAnrOrCrash` and
+`PdfViewerUiAutomatorTest.loadsThousandPageDocumentAndActivatesAdaptiveFlow` cases ran
+without being skipped so regressions cannot silently avoid the heavy document coverage. To
+reproduce the checks locally, run `./gradlew connectedAndroidTest` on an emulator or device
+and inspect `adb logcat` for `ANR in com.novapdf.reader` or fatal exception entries.
 
 ## Gradle wrapper bootstrap
 


### PR DESCRIPTION
## Summary
- extend the CI instrumentation verification step to require both the large-stress and thousand-page UI tests to run without skips or failures
- document the heavy PDF instrumentation expectations and ANR/crash validation in the README

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da5caf471c832bac94c0af64459c43