### PR TITLE
Ensure CI reruns heavy PDF instrumentation coverage

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -333,10 +333,10 @@ jobs:
           adb shell settings put global transition_animation_scale 0 || true
           adb shell settings put global animator_duration_scale 0 || true
           adb shell input keyevent 82 || true
-      - name: Run instrumentation tests
+      - name: Run instrumentation tests against stress PDFs
         run: |
           adb logcat -c || true
-          ./gradlew connectedAndroidTest --stacktrace
+          ./gradlew connectedAndroidTest --stacktrace --rerun-tasks --no-build-cache
       - name: Verify heavy PDF instrumentation coverage
         run: |
           set -euo pipefail

--- a/README.md
+++ b/README.md
@@ -49,9 +49,11 @@ Continuous integration now provisions a synthetic stress PDF with 32 pages that 
 panoramic, and extreme aspect ratios to exercise Pdfium rendering paths. Instrumentation
 tests open portrait, landscape, tall infographic, and ultra-wide panorama variants of the
 document and drive a thousand-page fixture through the UI to ensure the viewer can handle
-atypical source material. The workflow fails fast if logcat reports an Application Not
-Responding dialog, fatal Java exception, fatal signal, or forced process restart for
-`com.novapdf.reader`. It also verifies that both the
+atypical source material. The workflow invokes `connectedAndroidTest` with
+`--rerun-tasks --no-build-cache` so the heavy document scenarios always execute on every
+matrix device instead of being satisfied from prior outputs. It fails fast if logcat
+reports an Application Not Responding dialog, fatal Java exception, fatal signal, or forced
+process restart for `com.novapdf.reader`. It also verifies that both the
 `LargePdfInstrumentedTest.openLargeAndUnusualDocumentWithoutAnrOrCrash` and
 `PdfViewerUiAutomatorTest.loadsThousandPageDocumentAndActivatesAdaptiveFlow` cases ran
 without being skipped so regressions cannot silently avoid the heavy document coverage. To


### PR DESCRIPTION
## Summary
- force `connectedAndroidTest` to rerun without the Gradle build cache so stress-PDF instrumentation always executes in CI
- document the CI behaviour in the README so contributors understand the heavy-PDF checks

## Testing
- not run (CI only)


------
https://chatgpt.com/codex/tasks/task_e_68da88199704832b8a321a266cccd18d