### PR TITLE
Improve Compose message events and overlay accessibility

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -86,6 +86,8 @@
     <string name="thumbnail_strip_filter_label">Bookmarks only</string>
     <string name="thumbnail_strip_empty">Add bookmarks to see them here for faster navigation.</string>
     <string name="thumbnail_page_content_description">Thumbnail for page %1$d</string>
+    <string name="annotation_canvas_description">Annotation canvas for page %1$d. Double-tap and hold to begin drawing.</string>
+    <string name="search_highlight_description">Search highlights on this page: %1$d match(es) outlined.</string>
     <string name="open_source_dialog_title">Where is your PDF?</string>
     <string name="open_source_dialog_body">Choose how you\'d like to open your document.</string>
     <string name="open_source_device">Browse device storage</string>


### PR DESCRIPTION
## Summary
- emit transient snackbar messages from `PdfViewerViewModel` via a `SharedFlow` and collect them in Compose with `LaunchedEffect`
- enrich the annotation and search highlight overlays with semantics, talkback-friendly toggles, and localized descriptions
- add string resources for the new accessibility copy used by the overlays

## Testing
- ./gradlew :app:lintDebug --console=plain *(fails: existing NewApi lint error in ReaderActivity)*

------
https://chatgpt.com/codex/tasks/task_e_68dab8b4811c832bbfba5f895dfbccc2