### PR TITLE
Improve Compose messaging and overlay accessibility

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -43,6 +43,7 @@
     <string name="loading_document">Loading your document…</string>
     <string name="loading_progress">%1$d%% processed</string>
     <string name="render_progress_title">Rendering page %1$d…</string>
+    <string name="render_progress_announcement">Rendering page %1$d is %2$d%% complete.</string>
     <string name="loading_stage_resolving">Preparing document…</string>
     <string name="loading_stage_parsing">Analyzing PDF structure…</string>
     <string name="loading_stage_rendering">Rendering the first page…</string>


### PR DESCRIPTION
## Summary
- collect transient message flows with a lifecycle-aware Compose helper that also announces messages for accessibility
- add polite live region semantics to the render progress overlay with a dedicated announcement string to match modern Android guidance

## Testing
- ./gradlew lint --console=plain *(fails: Kotlin cache corruption in Gradle build cache)*

------
https://chatgpt.com/codex/tasks/task_e_68dabd710730832bb9856466ad76f7a6