### PR TITLE
Add crash reporting hooks for PDF errors

### DIFF
--- a/app/src/main/kotlin/com/novapdf/reader/NovaPdfApp.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/NovaPdfApp.kt
@@ -8,6 +8,8 @@ import com.novapdf.reader.data.BookmarkManager
 import com.novapdf.reader.data.NovaPdfDatabase
 import com.novapdf.reader.data.PdfDocumentRepository
 import com.novapdf.reader.work.DocumentMaintenanceScheduler
+import com.novapdf.reader.logging.CrashReporter
+import com.novapdf.reader.logging.FileCrashReporter
 import com.novapdf.reader.search.LuceneSearchCoordinator
 import com.novapdf.reader.data.remote.PdfDownloadManager
 import com.tom_roush.pdfbox.android.PDFBoxResourceLoader
@@ -29,12 +31,15 @@ open class NovaPdfApp : Application() {
         private set
     lateinit var pdfDownloadManager: PdfDownloadManager
         private set
+    lateinit var crashReporter: CrashReporter
+        private set
 
     override fun onCreate() {
         super.onCreate()
+        crashReporter = FileCrashReporter(this).also { it.install() }
         PDFBoxResourceLoader.init(applicationContext)
         annotationRepository = AnnotationRepository(this)
-        pdfDocumentRepository = PdfDocumentRepository(this)
+        pdfDocumentRepository = PdfDocumentRepository(this, crashReporter = crashReporter)
         searchCoordinator = LuceneSearchCoordinator(this, pdfDocumentRepository)
         adaptiveFlowManager = AdaptiveFlowManager(this)
         pdfDownloadManager = PdfDownloadManager(this)

--- a/app/src/main/kotlin/com/novapdf/reader/ReaderActivity.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/ReaderActivity.kt
@@ -228,7 +228,7 @@ open class ReaderActivity : ComponentActivity() {
                     viewModel.openDocument(uri)
                 }.onFailure { error ->
                     showUserSnackbar(getString(R.string.remote_pdf_download_failed))
-                    viewModel.reportRemoteOpenFailure(error)
+                    viewModel.reportRemoteOpenFailure(error, url)
                 }
             }
         }

--- a/app/src/main/kotlin/com/novapdf/reader/logging/CrashReporter.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/logging/CrashReporter.kt
@@ -1,0 +1,17 @@
+package com.novapdf.reader.logging
+
+/**
+ * Records crash and ANR diagnostics for the reader. This abstraction lets the production
+ * application plug into Firebase Crashlytics (or another backend) while keeping unit tests
+ * lightweight by injecting a no-op implementation.
+ */
+interface CrashReporter {
+    /** Installs any process-wide hooks such as uncaught exception handlers. */
+    fun install()
+
+    /** Records a non-fatal exception with optional contextual metadata. */
+    fun recordNonFatal(throwable: Throwable, metadata: Map<String, String> = emptyMap())
+
+    /** Adds a breadcrumb style message to the crash log. */
+    fun logBreadcrumb(message: String)
+}

--- a/app/src/main/kotlin/com/novapdf/reader/logging/FileCrashReporter.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/logging/FileCrashReporter.kt
@@ -1,0 +1,102 @@
+package com.novapdf.reader.logging
+
+import android.content.Context
+import android.util.Log
+import java.io.File
+import java.io.FileWriter
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.plus
+
+/**
+ * Lightweight crash logger that persists fatal and non-fatal exceptions to the app's private
+ * storage. This gives QA engineers actionable diagnostics on devices where third-party SDKs (such
+ * as Crashlytics) are not yet configured.
+ */
+class FileCrashReporter(
+    context: Context,
+    private val maxLogFiles: Int = 20
+) : CrashReporter {
+
+    private val applicationScope: CoroutineScope = CoroutineScope(Job()) + Dispatchers.IO
+    private val appContext = context.applicationContext
+    private val logDirectory: File = File(appContext.filesDir, "crashlogs").apply { mkdirs() }
+    private val timestampFormatter: DateTimeFormatter =
+        DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss-SSS", Locale.US).withZone(ZoneOffset.UTC)
+    private val installed = AtomicBoolean(false)
+    private val defaultHandler = Thread.getDefaultUncaughtExceptionHandler()
+
+    override fun install() {
+        if (!installed.compareAndSet(false, true)) {
+            return
+        }
+        Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
+            persist("fatal", throwable.stackTraceToString(), mapOf("thread" to thread.name))
+            defaultHandler?.uncaughtException(thread, throwable)
+        }
+    }
+
+    override fun recordNonFatal(throwable: Throwable, metadata: Map<String, String>) {
+        val mergedMetadata = metadata.toMutableMap().apply {
+            put("type", throwable::class.java.name)
+        }
+        persist("nonfatal", throwable.stackTraceToString(), mergedMetadata)
+    }
+
+    override fun logBreadcrumb(message: String) {
+        persist("breadcrumb", message)
+    }
+
+    private fun persist(kind: String, body: String, metadata: Map<String, String> = emptyMap()) {
+        val timestamp = timestampFormatter.format(Instant.now())
+        val fileName = "$timestamp-$kind.log"
+        val entry = buildString {
+            appendLine("timestamp=$timestamp")
+            appendLine("kind=$kind")
+            metadata.forEach { (key, value) ->
+                appendLine("$key=${value.replace('\n', ' ')}")
+            }
+            appendLine()
+            append(body)
+            if (!body.endsWith('\n')) {
+                append('\n')
+            }
+        }
+        applicationScope.launch {
+            runCatching {
+                writeLog(File(logDirectory, fileName), entry)
+                trimLogs()
+            }.onFailure { error ->
+                Log.w(TAG, "Unable to persist crash log", error)
+            }
+        }
+    }
+
+    private fun writeLog(file: File, entry: String) {
+        FileWriter(file, false).use { writer ->
+            writer.write(entry)
+            writer.flush()
+        }
+    }
+
+    private fun trimLogs() {
+        val logs = logDirectory.listFiles { candidate -> candidate.extension.equals("log", true) }
+            ?.sortedByDescending(File::lastModified)
+            ?: return
+        if (logs.size <= maxLogFiles) return
+        logs.drop(maxLogFiles).forEach { candidate ->
+            runCatching { candidate.delete() }
+        }
+    }
+
+    companion object {
+        private const val TAG = "FileCrashReporter"
+    }
+}

--- a/app/src/test/kotlin/com/novapdf/reader/TestPdfApp.kt
+++ b/app/src/test/kotlin/com/novapdf/reader/TestPdfApp.kt
@@ -6,6 +6,7 @@ import com.novapdf.reader.data.AnnotationRepository
 import com.novapdf.reader.data.BookmarkManager
 import com.novapdf.reader.data.PdfDocumentRepository
 import com.novapdf.reader.data.remote.PdfDownloadManager
+import com.novapdf.reader.logging.CrashReporter
 import com.novapdf.reader.search.LuceneSearchCoordinator
 import com.novapdf.reader.work.DocumentMaintenanceScheduler
 
@@ -22,6 +23,11 @@ class TestPdfApp : NovaPdfApp() {
         documentMaintenanceScheduler: DocumentMaintenanceScheduler,
         searchCoordinator: LuceneSearchCoordinator,
         pdfDownloadManager: PdfDownloadManager,
+        crashReporter: CrashReporter = object : CrashReporter {
+            override fun install() = Unit
+            override fun recordNonFatal(throwable: Throwable, metadata: Map<String, String>) = Unit
+            override fun logBreadcrumb(message: String) = Unit
+        },
     ) {
         setField("annotationRepository", annotationRepository)
         setField("pdfDocumentRepository", pdfRepository)
@@ -30,6 +36,7 @@ class TestPdfApp : NovaPdfApp() {
         setField("documentMaintenanceScheduler", documentMaintenanceScheduler)
         setField("searchCoordinator", searchCoordinator)
         setField("pdfDownloadManager", pdfDownloadManager)
+        setField("crashReporter", crashReporter)
     }
 
     private fun setField(name: String, value: Any) {


### PR DESCRIPTION
## Summary
- add a CrashReporter abstraction with a file-backed implementation and register it during app startup
- record PDF load/render failures via the CrashReporter and surface richer metadata to the UI when loads fail
- ensure remote download errors carry their source URL and expose a no-op crash reporter for unit tests

## Testing
- ./gradlew clean testDebugUnitTest --no-daemon --console=plain


------
https://chatgpt.com/codex/tasks/task_e_68dac046c384832ba44772a7d44e69be