### PR TITLE
Defer heavy PDF initialization off the main thread

### DIFF
--- a/app/src/main/kotlin/com/novapdf/reader/search/LuceneSearchCoordinator.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/search/LuceneSearchCoordinator.kt
@@ -211,6 +211,7 @@ class LuceneSearchCoordinator(
     private suspend fun extractPageContent(session: PdfDocumentSession): List<PageSearchContent> = withContext(Dispatchers.IO) {
         val pageCount = session.pageCount
         if (pageCount <= 0) return@withContext emptyList()
+        PdfBoxInitializer.ensureInitialized(context)
         val contents = MutableList(pageCount) {
             PageSearchContent(
                 text = "",

--- a/app/src/main/kotlin/com/novapdf/reader/search/PdfBoxInitializer.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/search/PdfBoxInitializer.kt
@@ -1,0 +1,26 @@
+package com.novapdf.reader.search
+
+import android.content.Context
+import com.tom_roush.pdfbox.android.PDFBoxResourceLoader
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+
+internal object PdfBoxInitializer {
+    private val initialized = AtomicBoolean(false)
+    private val mutex = Mutex()
+
+    suspend fun ensureInitialized(context: Context) {
+        if (initialized.get()) return
+        mutex.withLock {
+            if (!initialized.get()) {
+                withContext(Dispatchers.IO) {
+                    PDFBoxResourceLoader.init(context.applicationContext)
+                }
+                initialized.set(true)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- lazily initialize NovaPdfApp singletons and prewarm expensive components off the main thread to prevent startup hangs
- add a PdfBoxInitializer helper that ensures PDFBox is initialised on demand from background threads
- gate LuceneSearchCoordinator text extraction on PdfBox initialization so background work is ready before use

## Testing
- ./gradlew test --no-daemon --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68db6679057c832b802fcb819dcbf7bc