### PR TITLE
Fix PdfViewerScreenTest compilation

### DIFF
--- a/app/src/androidTest/kotlin/com/novapdf/reader/PdfViewerScreenTest.kt
+++ b/app/src/androidTest/kotlin/com/novapdf/reader/PdfViewerScreenTest.kt
@@ -12,6 +12,7 @@ import com.novapdf.reader.ui.theme.NovaPdfTheme
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import kotlinx.coroutines.flow.emptyFlow
 
 @RunWith(AndroidJUnit4::class)
 class PdfViewerScreenTest {
@@ -26,6 +27,7 @@ class PdfViewerScreenTest {
                 PdfViewerScreen(
                     state = PdfViewerUiState(),
                     snackbarHost = androidx.compose.material3.SnackbarHostState(),
+                    messageFlow = emptyFlow(),
                     onOpenLocalDocument = {},
                     onOpenCloudDocument = {},
                     onOpenRemoteDocument = { _ -> },


### PR DESCRIPTION
## Summary
- provide an empty Flow to the PdfViewerScreen test so it matches the composable signature

## Testing
- ./gradlew :app:compileDebugAndroidTestKotlin

------
https://chatgpt.com/codex/tasks/task_e_68db782a31e4832ba160f9004b6d2221