### PR TITLE
Recycle legacy adapter bitmaps when clearing state

### DIFF
--- a/app/src/main/kotlin/com/novapdf/reader/legacy/LegacyPdfPageAdapter.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/legacy/LegacyPdfPageAdapter.kt
@@ -58,6 +58,11 @@ class LegacyPdfPageAdapter(
     fun clear() {
         pageJobs.forEach { _, job -> job.cancel() }
         pageJobs.clear()
+        bitmaps.forEach { _, bitmap ->
+            if (!bitmap.isRecycled) {
+                bitmap.recycle()
+            }
+        }
         bitmaps.clear()
         pageIndices.clear()
         currentDocumentId = null


### PR DESCRIPTION
## Summary
- recycle cached bitmap instances before clearing the legacy PDF adapter cache to avoid leaking graphics memory

## Testing
- ./gradlew test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68db8ad005f0832ba08c63b857a6b3d9