### PR TITLE
Switch CI emulator devices to API 32 to avoid ANRs

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -18,8 +18,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - api: 34
-            avd: pixel7pro_api34
+          - api: 32
+            avd: pixel7pro_api32
             tag: google_apis
             abi: x86_64
             ram_mb: 6144
@@ -36,8 +36,8 @@ jobs:
               hw.displayRegion.0.height=3120
               hw.displayRegion.0.xOffset=0
               hw.displayRegion.0.yOffset=0
-          - api: 34
-            avd: galaxys24ultra_api34
+          - api: 32
+            avd: galaxys24ultra_api32
             tag: google_apis
             abi: x86_64
             ram_mb: 8192
@@ -54,8 +54,8 @@ jobs:
               hw.displayRegion.0.height=3120
               hw.displayRegion.0.xOffset=0
               hw.displayRegion.0.yOffset=0
-          - api: 34
-            avd: galaxys23ultra_api34
+          - api: 32
+            avd: galaxys23ultra_api32
             tag: google_apis
             abi: x86_64
             ram_mb: 7168
@@ -72,8 +72,8 @@ jobs:
               hw.displayRegion.0.height=3088
               hw.displayRegion.0.xOffset=0
               hw.displayRegion.0.yOffset=0
-          - api: 34
-            avd: pixelfold_api34
+          - api: 32
+            avd: pixelfold_api32
             tag: google_apis
             abi: x86_64
             ram_mb: 6144
@@ -90,8 +90,8 @@ jobs:
               hw.displayRegion.0.height=2208
               hw.displayRegion.0.xOffset=0
               hw.displayRegion.0.yOffset=0
-          - api: 33
-            avd: pixeltablet_api33
+          - api: 32
+            avd: pixeltablet_api32
             tag: google_apis
             abi: x86_64
             ram_mb: 8192

--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ See `docs/sample-pdf-license.md` for the redistribution notice covering the bund
 ## Running connected Android tests locally
 
 Instrumentation and macrobenchmark tests require an Android SDK installation that includes
-the `platform-tools`, `build-tools`, and emulator components for API level 35.
+the `platform-tools`, `build-tools`, and emulator components for API level 32.
 
 1. Install the Android command-line tools and use `sdkmanager` to download the required
    packages:
 
    ```bash
-   sdkmanager "platform-tools" "build-tools;35.0.0" "platforms;android-35" "emulator"
+  sdkmanager "platform-tools" "build-tools;34.0.0" "platforms;android-32" "emulator"
    ```
 
 2. Point Gradle to your SDK installation by setting `ANDROID_SDK_ROOT`/`ANDROID_HOME` or by


### PR DESCRIPTION
## Summary
- switch the GitHub Actions emulator matrix to use API level 32 system images so the emulator boots without Process System ANRs
- update the local testing instructions to match the API 32 system image requirement

## Testing
- ./gradlew testDebugUnitTest


------
https://chatgpt.com/codex/tasks/task_e_68dbce0bfdc8832b829d269472f71ae9