### PR TITLE
Ensure CI emulator cold boots in CI

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -297,7 +297,8 @@ jobs:
             accel_args=("-no-accel" "-accel" "off")
           fi
 
-          $ANDROID_HOME/emulator/emulator -avd ${{ matrix.avd }} -no-snapshot -no-window -gpu swiftshader_indirect -memory ${{ matrix.ram_mb }} -skin ${{ matrix.skin }} -camera-back none -camera-front none -no-boot-anim "${accel_args[@]}" "${disk_partition_args[@]}" &
+          # Force a cold boot (-wipe-data) to clear stale emulator state that can lead to ANRs between runs.
+          $ANDROID_HOME/emulator/emulator -avd ${{ matrix.avd }} -no-snapshot -wipe-data -no-window -gpu swiftshader_indirect -memory ${{ matrix.ram_mb }} -skin ${{ matrix.skin }} -camera-back none -camera-front none -no-boot-anim "${accel_args[@]}" "${disk_partition_args[@]}" &
           emulator_pid=$!
 
           device_timeout=0


### PR DESCRIPTION
## Summary
- force the GitHub Actions emulator invocation to include `-wipe-data` so each run starts from a cold boot
- document the cold boot requirement in the workflow for future maintainers

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68dbd05fe4d0832b855b1c4a9d421eb5