### PR TITLE
Add integrity validation after downloading remote PDFs

### DIFF
--- a/app/src/main/kotlin/com/novapdf/reader/data/remote/PdfDownloadManager.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/data/remote/PdfDownloadManager.kt
@@ -2,11 +2,15 @@ package com.novapdf.reader.data.remote
 
 import android.content.Context
 import android.net.Uri
+import android.os.ParcelFileDescriptor
 import androidx.core.content.FileProvider
 import coil3.ImageLoader
 import coil3.request.ErrorResult
 import coil3.request.ImageRequest
+import com.shockwave.pdfium.PdfDocument
+import com.shockwave.pdfium.PdfiumCore
 import java.io.File
+import java.io.IOException
 import java.util.UUID
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
@@ -23,6 +27,7 @@ class PdfDownloadManager(
             add(PdfDownloadDecoder.Factory())
         }
         .build()
+    private val pdfiumCore = PdfiumCore(appContext)
 
     suspend fun download(url: String): Result<Uri> = withContext(Dispatchers.IO) {
         val destination = File(downloadDirectory, buildFileName())
@@ -55,20 +60,51 @@ class PdfDownloadManager(
             .build()
 
         val executeResult = imageLoader.execute(request)
-        return@withContext try {
+        val outcome = try {
             val file = deferred.await()
+            validateDownloadedPdf(file)
             val uri = FileProvider.getUriForFile(appContext, authority, file)
             Result.success(uri)
         } catch (error: Throwable) {
+            destination.delete()
             Result.failure(error)
-        } finally {
-            if (executeResult is coil3.request.ErrorResult) {
-                destination.delete()
-            }
         }
+
+        if (executeResult is ErrorResult) {
+            destination.delete()
+        }
+
+        return@withContext outcome
     }
 
     private fun buildFileName(): String {
         return "remote_${UUID.randomUUID()}.pdf"
+    }
+
+    private fun validateDownloadedPdf(file: File) {
+        val length = file.length()
+        if (length <= 0L) {
+            throw IOException("Downloaded PDF is empty")
+        }
+
+        var descriptor: ParcelFileDescriptor? = null
+        var document: PdfDocument? = null
+        try {
+            descriptor = ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY)
+            document = pdfiumCore.newDocument(descriptor)
+            val pageCount = pdfiumCore.getPageCount(document)
+            if (pageCount <= 0) {
+                throw IOException("Downloaded PDF has no pages")
+            }
+        } catch (error: Throwable) {
+            throw IOException("Downloaded PDF failed integrity check", error)
+        } finally {
+            document?.let { doc ->
+                runCatching { pdfiumCore.closeDocument(doc) }
+            }
+            descriptor?.let { pfd ->
+                runCatching { pfd.close() }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- validate downloaded PDF files before exposing their URIs
- delete invalid downloads and fail fast when integrity checks do not pass

## Testing
- ./gradlew :app:testDebugUnitTest --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68dbdb8543d0832bb8164cc509a7828e