### PR TITLE
Silence AWS S3 copy progress in CI

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -440,7 +440,7 @@ jobs:
             local tmp="${dest}.tmp"
 
             echo "Downloading ${label} fixture from s3://${BUCKET}/${key}"
-            if ! aws s3 cp "s3://${BUCKET}/${key}" "$tmp"; then
+            if ! aws s3 cp --only-show-errors "s3://${BUCKET}/${key}" "$tmp"; then
               echo "::error::Failed to download ${label} PDF fixture from s3://${BUCKET}/${key}"
               rm -f "$tmp"
               exit 1


### PR DESCRIPTION
## Summary
- add the `--only-show-errors` flag to the stress fixture download step so the workflow output only contains the intended values

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68dbf8060494832b9b3d37ca70f478cf