### PR TITLE
Fix fixture download logging in CI

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -439,7 +439,7 @@ jobs:
             local dest="$FIXTURE_DIR/$(basename "$key")"
             local tmp="${dest}.tmp"
 
-            echo "Downloading ${label} fixture from s3://${BUCKET}/${key}"
+            echo "Downloading ${label} fixture from s3://${BUCKET}/${key}" >&2
             if ! aws s3 cp --only-show-errors "s3://${BUCKET}/${key}" "$tmp"; then
               echo "::error::Failed to download ${label} PDF fixture from s3://${BUCKET}/${key}"
               rm -f "$tmp"


### PR DESCRIPTION
## Summary
- redirect the fixture download log message to stderr so command substitution only captures the file path

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68dc02643760832badf69739012e203a