### PR TITLE
Fix staging of stress PDF fixtures on emulator

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -486,38 +486,14 @@ jobs:
 
           adb wait-for-device
 
-          prepare_download_dir() {
-            local candidate="$1"
-
-            if adb shell "[ -d ${candidate} ]" >/dev/null 2>&1; then
-              DOWNLOAD_DIR="$candidate"
-              return 0
-            fi
-
-            if adb shell "mkdir -p ${candidate}" >/dev/null 2>&1; then
-              DOWNLOAD_DIR="$candidate"
-              return 0
-            fi
-
-            return 1
-          }
-
-          DOWNLOAD_DIR=""
-
-          if ! prepare_download_dir "/sdcard/Download"; then
-            if ! prepare_download_dir "/storage/emulated/0/Download"; then
-              echo "::error::Unable to prepare a shared Download directory on the emulator"
-              exit 1
-            fi
-          fi
-
           stage_fixture() {
             local src="$1"
             local dest_name="$2"
 
-            adb push "$src" "${DOWNLOAD_DIR}/${dest_name}" >/dev/null
-
-            adb shell run-as "$PACKAGE_NAME" sh -c "set -e; mkdir -p cache; cp '${DOWNLOAD_DIR}/${dest_name}' 'cache/${dest_name}'"
+            if ! adb shell run-as "$PACKAGE_NAME" sh -c "set -e; mkdir -p cache; cat > 'cache/${dest_name}'" < "$src"; then
+              echo "::error::Failed to stream ${dest_name} into application cache"
+              exit 1
+            fi
 
             if ! adb shell run-as "$PACKAGE_NAME" sh -c "[ -s 'cache/${dest_name}' ]"; then
               echo "::error::Failed to stage ${dest_name} in application cache"


### PR DESCRIPTION
## Summary
- avoid relying on shared Download directories when staging stress PDF fixtures
- stream each fixture directly into the app cache via `run-as` so instrumentation can read it

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68dc0b9bc1b4832bb5678edf24b3aa55