### PR TITLE
Install debug build before staging PDF fixtures

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -411,6 +411,10 @@ jobs:
           adb shell settings put global transition_animation_scale 0 || true
           adb shell settings put global animator_duration_scale 0 || true
           adb shell input keyevent 82 || true
+      - name: Install app under test
+        run: |
+          set -euo pipefail
+          ./gradlew :app:installDebug --no-build-cache
       - name: Fetch stress PDF fixtures from S3
         id: fetch_pdfs
         env:


### PR DESCRIPTION
## Summary
- install the debug variant on the emulator before attempting to stage PDF fixtures so `adb run-as` can access the app cache

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc10cfd608832b83a89567aac4bd61