### PR TITLE
Handle stress PDF staging fallback

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -557,13 +557,20 @@ jobs:
             local src="$1"
             local dest_name="$2"
 
-            if ! adb shell run-as "$PACKAGE_NAME" sh -c "set -e; mkdir -p cache; cat > 'cache/${dest_name}'" < "$src"; then
-              echo "::error::Failed to stream ${dest_name} into application cache"
-              exit 1
+            local staged_path="cache/${dest_name}"
+
+            if ! adb shell run-as "$PACKAGE_NAME" sh -c "set -e; mkdir -p cache; cat > '${staged_path}'" < "$src"; then
+              echo "Failed to write ${dest_name} into cache; attempting files directory fallback" >&2
+
+              staged_path="files/${dest_name}"
+              if ! adb shell run-as "$PACKAGE_NAME" sh -c "set -e; mkdir -p files; cat > '${staged_path}'" < "$src"; then
+                echo "::error::Failed to stream ${dest_name} into application internal storage"
+                exit 1
+              fi
             fi
 
-            if ! adb shell run-as "$PACKAGE_NAME" sh -c "[ -s 'cache/${dest_name}' ]"; then
-              echo "::error::Failed to stage ${dest_name} in application cache"
+            if ! adb shell run-as "$PACKAGE_NAME" sh -c "[ -s '${staged_path}' ]"; then
+              echo "::error::Failed to stage ${dest_name} in application storage"
               exit 1
             fi
           }


### PR DESCRIPTION
## Summary
- allow instrumentation fixtures to locate pre-staged PDFs from multiple internal storage directories
- fall back to the files directory when CI staging cannot write to the cache directory

## Testing
- ./gradlew testDebugUnitTest --no-daemon

------
https://chatgpt.com/codex/tasks/task_e_68dca2d7e5e0832ba2026ad4ec4c5cce