### PR TITLE
Handle read-only app storage when generating stress PDFs

### DIFF
--- a/app/src/androidTest/kotlin/com/novapdf/reader/StorageDirectoryCandidates.kt
+++ b/app/src/androidTest/kotlin/com/novapdf/reader/StorageDirectoryCandidates.kt
@@ -1,0 +1,53 @@
+package com.novapdf.reader
+
+import android.content.Context
+import android.os.Build
+import java.io.File
+import java.io.IOException
+
+internal fun writableStorageCandidates(context: Context): List<File> {
+    val directories = buildList {
+        context.cacheDir?.let(::add)
+        context.filesDir?.let(::add)
+        context.codeCacheDir?.let(::add)
+        context.noBackupFilesDir?.let(::add)
+        context.externalCacheDir?.let(::add)
+        context.externalCacheDirs?.forEach { dir -> dir?.let(::add) }
+        context.getExternalFilesDir(null)?.let(::add)
+        context.getExternalFilesDirs(null)?.forEach { dir -> dir?.let(::add) }
+        context.externalMediaDirs?.forEach { dir -> dir?.let(::add) }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            context.dataDir?.let(::add)
+        }
+    }
+
+    return directories
+        .mapNotNull(::prepareWritableDirectory)
+        .distinctBy { it.absolutePath }
+}
+
+private fun prepareWritableDirectory(directory: File?): File? {
+    if (directory == null) return null
+
+    return try {
+        if (!directory.exists() && !directory.mkdirs()) {
+            return null
+        }
+
+        val probe = File(directory, ".storage-probe-${'$'}{System.nanoTime()}")
+        try {
+            probe.outputStream().use { /* Ensure we can create and close a file */ }
+            directory
+        } catch (error: IOException) {
+            null
+        } catch (error: SecurityException) {
+            null
+        } finally {
+            if (probe.exists() && !probe.delete()) {
+                // Ignore failure to delete the probe file; it is harmless temporary state.
+            }
+        }
+    } catch (error: SecurityException) {
+        null
+    }
+}

--- a/app/src/androidTest/kotlin/com/novapdf/reader/StressDocumentFactory.kt
+++ b/app/src/androidTest/kotlin/com/novapdf/reader/StressDocumentFactory.kt
@@ -20,7 +20,7 @@ internal object StressDocumentFactory {
     private const val PAGE_COUNT = 32
 
     suspend fun installStressDocument(context: Context) = withContext(Dispatchers.IO) {
-        val candidateDirectories = internalStorageCandidates(context)
+        val candidateDirectories = writableStorageCandidates(context)
 
         val existing = candidateDirectories
             .map { File(it, LARGE_CACHE_FILE_NAME) }
@@ -48,13 +48,6 @@ internal object StressDocumentFactory {
         failures.forEach(failure::addSuppressed)
         throw failure
     }
-
-    private fun internalStorageCandidates(context: Context): List<File> = buildList {
-        context.cacheDir?.let(::add)
-        context.filesDir?.let(::add)
-        context.codeCacheDir?.let(::add)
-        context.noBackupFilesDir?.let(::add)
-    }.distinct()
 
     private fun generateStressDocument(destination: File) {
         val parentDir = destination.parentFile ?: throw IOException("Missing cache directory for stress PDF")

--- a/app/src/androidTest/kotlin/com/novapdf/reader/TestDocumentFixtures.kt
+++ b/app/src/androidTest/kotlin/com/novapdf/reader/TestDocumentFixtures.kt
@@ -15,7 +15,7 @@ internal object TestDocumentFixtures {
 
     suspend fun installThousandPageDocument(context: Context): android.net.Uri =
         withContext(Dispatchers.IO) {
-        val candidateDirectories = internalStorageCandidates(context)
+        val candidateDirectories = writableStorageCandidates(context)
 
         val existing = candidateDirectories
             .map { File(it, THOUSAND_PAGE_CACHE) }
@@ -33,13 +33,6 @@ internal object TestDocumentFixtures {
         createThousandPagePdf(destination)
         destination.toUri()
     }
-
-    private fun internalStorageCandidates(context: Context): List<File> = buildList {
-        context.cacheDir?.let(::add)
-        context.filesDir?.let(::add)
-        context.codeCacheDir?.let(::add)
-        context.noBackupFilesDir?.let(::add)
-    }.distinct()
 
     private fun createThousandPagePdf(destination: File) {
         val pdf = PdfDocument()


### PR DESCRIPTION
## Summary
- add a shared helper that filters context directories down to writable locations
- update the stress and thousand-page fixtures to use the helper when generating PDFs

## Testing
- ./gradlew :app:compileDebugAndroidTestKotlin --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68dcb5f640d0832b91c93f20d48db7fe