### PR TITLE
Fix staging of stress PDFs on emulator

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -553,23 +553,29 @@ jobs:
 
           adb wait-for-device
 
+          app_data_dir=$(adb shell run-as "$PACKAGE_NAME" sh -c 'pwd' | tr -d '\r' | tr -d '\n')
+          if [ -z "$app_data_dir" ]; then
+            echo "::error::Unable to determine application data directory via run-as"
+            exit 1
+          fi
+
           stage_fixture() {
             local src="$1"
             local dest_name="$2"
 
             local staged_path="cache/${dest_name}"
 
-            if ! adb shell run-as "$PACKAGE_NAME" sh -c "set -e; mkdir -p cache; cat > '${staged_path}'" < "$src"; then
+            if ! adb shell run-as "$PACKAGE_NAME" sh -c "set -e; cd '$app_data_dir'; mkdir -p cache; cat > '${staged_path}'" < "$src"; then
               echo "Failed to write ${dest_name} into cache; attempting files directory fallback" >&2
 
               staged_path="files/${dest_name}"
-              if ! adb shell run-as "$PACKAGE_NAME" sh -c "set -e; mkdir -p files; cat > '${staged_path}'" < "$src"; then
+              if ! adb shell run-as "$PACKAGE_NAME" sh -c "set -e; cd '$app_data_dir'; mkdir -p files; cat > '${staged_path}'" < "$src"; then
                 echo "::error::Failed to stream ${dest_name} into application internal storage"
                 exit 1
               fi
             fi
 
-            if ! adb shell run-as "$PACKAGE_NAME" sh -c "[ -s '${staged_path}' ]"; then
+            if ! adb shell run-as "$PACKAGE_NAME" sh -c "cd '$app_data_dir'; [ -s '${staged_path}' ]"; then
               echo "::error::Failed to stage ${dest_name} in application storage"
               exit 1
             fi


### PR DESCRIPTION
## Summary
- determine the application data directory using `run-as` during the staging step
- change the stress PDF staging helper to operate from that directory before writing files

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68dcbb5fd044832b82b8082b55d10cb9