### PR TITLE
Fix stress PDF staging to avoid run-as directory permission errors

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -559,23 +559,25 @@ jobs:
             exit 1
           fi
 
+          echo "Application data directory resolved to $app_data_dir"
+
           stage_fixture() {
             local src="$1"
             local dest_name="$2"
 
             local staged_path="cache/${dest_name}"
 
-            if ! adb shell run-as "$PACKAGE_NAME" sh -c "set -e; cd '$app_data_dir'; mkdir -p cache; cat > '${staged_path}'" < "$src"; then
+            if ! adb shell run-as "$PACKAGE_NAME" sh -c "set -e; mkdir -p cache; cat > '${staged_path}'" < "$src"; then
               echo "Failed to write ${dest_name} into cache; attempting files directory fallback" >&2
 
               staged_path="files/${dest_name}"
-              if ! adb shell run-as "$PACKAGE_NAME" sh -c "set -e; cd '$app_data_dir'; mkdir -p files; cat > '${staged_path}'" < "$src"; then
+              if ! adb shell run-as "$PACKAGE_NAME" sh -c "set -e; mkdir -p files; cat > '${staged_path}'" < "$src"; then
                 echo "::error::Failed to stream ${dest_name} into application internal storage"
                 exit 1
               fi
             fi
 
-            if ! adb shell run-as "$PACKAGE_NAME" sh -c "cd '$app_data_dir'; [ -s '${staged_path}' ]"; then
+            if ! adb shell run-as "$PACKAGE_NAME" sh -c "[ -s '${staged_path}' ]"; then
               echo "::error::Failed to stage ${dest_name} in application storage"
               exit 1
             fi


### PR DESCRIPTION
## Summary
- update the stress-PDF staging step to write directly from the app user's default directory instead of attempting to cd into it
- add logging for the resolved application data directory to help diagnose future staging issues

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68dcc4947f2c832bbbb300585ecb381a