### PR TITLE
Fix stress PDF staging to app data directory

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -565,19 +565,25 @@ jobs:
             local src="$1"
             local dest_name="$2"
 
-            local staged_path="cache/${dest_name}"
+            local cache_dir="${app_data_dir}/cache"
+            local cache_path="${cache_dir}/${dest_name}"
 
-            if ! adb shell run-as "$PACKAGE_NAME" sh -c "set -e; mkdir -p cache; cat > '${staged_path}'" < "$src"; then
+            local staged_path="$cache_path"
+
+            if ! adb shell run-as "$PACKAGE_NAME" sh -c "set -e; mkdir -p \"${cache_dir}\"; cat > \"${cache_path}\"" < "$src"; then
               echo "Failed to write ${dest_name} into cache; attempting files directory fallback" >&2
 
-              staged_path="files/${dest_name}"
-              if ! adb shell run-as "$PACKAGE_NAME" sh -c "set -e; mkdir -p files; cat > '${staged_path}'" < "$src"; then
+              local files_dir="${app_data_dir}/files"
+              local files_path="${files_dir}/${dest_name}"
+              staged_path="$files_path"
+
+              if ! adb shell run-as "$PACKAGE_NAME" sh -c "set -e; mkdir -p \"${files_dir}\"; cat > \"${files_path}\"" < "$src"; then
                 echo "::error::Failed to stream ${dest_name} into application internal storage"
                 exit 1
               fi
             fi
 
-            if ! adb shell run-as "$PACKAGE_NAME" sh -c "[ -s '${staged_path}' ]"; then
+            if ! adb shell run-as "$PACKAGE_NAME" sh -c "[ -s \"${staged_path}\" ]"; then
               echo "::error::Failed to stage ${dest_name} in application storage"
               exit 1
             fi


### PR DESCRIPTION
## Summary
- ensure stress PDF fixtures are copied into the emulator using absolute paths inside the app data directory
- fall back to the files directory with the same absolute-path approach and keep verification consistent

## Testing
- not run (CI environment)

------
https://chatgpt.com/codex/tasks/task_e_68dccc670a3c832b9b17b7ef6e82b1e1