### PR TITLE
Fix AWS CLI setup action reference in CI workflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -229,7 +229,7 @@ jobs:
       - name: Add Android platform tools to PATH
         run: echo "$ANDROID_HOME/platform-tools" >> "$GITHUB_PATH"
       - name: Set up AWS CLI
-        uses: actions/setup-aws-cli@v2
+        uses: aws-actions/setup-aws-cli@v2
       - name: Validate AWS credential scope
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
## Summary
- correct the GitHub Actions step that installs the AWS CLI to use the maintained aws-actions/setup-aws-cli action

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dce45e6b88832b9bd52953cb0401fd