### PR TITLE
Handle remote PDF download failures gracefully

### DIFF
--- a/app/src/main/kotlin/com/novapdf/reader/ReaderActivity.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/ReaderActivity.kt
@@ -29,6 +29,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.novapdf.reader.R
 import com.novapdf.reader.data.remote.PdfDownloadManager
+import com.novapdf.reader.data.remote.RemotePdfException
 import com.novapdf.reader.ui.theme.NovaPdfTheme
 import com.novapdf.reader.legacy.LegacyPdfPageAdapter
 import com.google.android.material.appbar.MaterialToolbar
@@ -227,7 +228,14 @@ open class ReaderActivity : ComponentActivity() {
                 result.onSuccess { uri ->
                     viewModel.openDocument(uri)
                 }.onFailure { error ->
-                    showUserSnackbar(getString(R.string.remote_pdf_download_failed))
+                    val messageRes = if (error is RemotePdfException &&
+                        error.reason == RemotePdfException.Reason.CORRUPTED
+                    ) {
+                        R.string.error_pdf_corrupted
+                    } else {
+                        R.string.remote_pdf_download_failed
+                    }
+                    showUserSnackbar(getString(messageRes))
                     viewModel.reportRemoteOpenFailure(error, url)
                 }
             }

--- a/app/src/main/kotlin/com/novapdf/reader/data/remote/RemotePdfException.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/data/remote/RemotePdfException.kt
@@ -1,0 +1,11 @@
+package com.novapdf.reader.data.remote
+
+class RemotePdfException(
+    val reason: Reason,
+    cause: Throwable? = null,
+) : Exception(reason.name, cause) {
+    enum class Reason {
+        NETWORK,
+        CORRUPTED,
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated `RemotePdfException` and wrap all remote download failures when retrieving external PDFs
- update the downloader, view model, and legacy UI to surface specific messaging when a download fails or a corrupted file is detected
- expand unit coverage to assert corrupted remote files trigger the corruption error path

## Testing
- ./gradlew :app:testDebugUnitTest --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68dcf55d6d20832ba2fffb8781655ab8