### PR TITLE
Fix runner temp reference in Firebase instrumentation job

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -972,8 +972,9 @@ jobs:
             version: 33
     env:
       FIREBASE_PROJECT_ID: ${{ vars.FIREBASE_PROJECT_ID || secrets.FIREBASE_PROJECT_ID }}
-      RESULTS_JSON: ${{ runner.temp }}/firebase-results.json
     steps:
+      - name: Configure Firebase results path
+        run: echo "RESULTS_JSON=$RUNNER_TEMP/firebase-results.json" >> "$GITHUB_ENV"
       - name: Validate Firebase configuration
         run: |
           set -e


### PR DESCRIPTION
## Summary
- replace the invalid `runner.temp` expression with a shell export of RESULTS_JSON
- ensure the Firebase instrumentation job writes the results path to `$GITHUB_ENV`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcfa09583c832b939a2ebe0f7aaaa8