### PR TITLE
Add instrumentation-driven PDF screenshot harness

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -848,13 +848,71 @@ jobs:
           base_dir="${ARTIFACTS_DIR}/screenshots/api${{ matrix.api }}/${{ matrix.device_label }}"
           mkdir -p "$base_dir"
 
-          adb shell am start -n com.novapdf.reader/.MainActivity
+          PACKAGE_NAME="com.novapdf.reader"
+          READY_FLAG="cache/screenshot_ready.flag"
+          DONE_FLAG="cache/screenshot_done.flag"
+          HARNESS_CLASS="com.novapdf.reader.ScreenshotHarnessTest#openThousandPageDocumentForScreenshots"
+          HARNESS_LOG="$base_dir/screenshot-harness.log"
+
+          cleanup_flags() {
+            adb shell run-as "$PACKAGE_NAME" sh -c "rm -f '$READY_FLAG' '$DONE_FLAG'" >/dev/null 2>&1 || true
+          }
+
+          cleanup_flags
+
+          harness_pid=""
+          finish_harness() {
+            if [ -n "${harness_pid:-}" ] && kill -0 "$harness_pid" >/dev/null 2>&1; then
+              echo "Stopping screenshot harness instrumentation" >&2
+              kill "$harness_pid" >/dev/null 2>&1 || true
+              wait "$harness_pid" >/dev/null 2>&1 || true
+            fi
+            cleanup_flags
+          }
+          trap finish_harness EXIT
+
+          echo "Launching screenshot harness instrumentation to load thousand-page PDF"
+          adb shell am instrument -w -r \
+            -e runScreenshotHarness true \
+            -e class "$HARNESS_CLASS" \
+            com.novapdf.reader.test/androidx.test.runner.AndroidJUnitRunner \
+            >"$HARNESS_LOG" 2>&1 &
+          harness_pid=$!
+
+          wait_for_harness() {
+            local elapsed=0
+            local timeout=$((5 * 60))
+            while true; do
+              if ! kill -0 "$harness_pid" >/dev/null 2>&1; then
+                echo "::error::Screenshot harness instrumentation exited before reporting readiness" >&2
+                cat "$HARNESS_LOG" >&2 || true
+                wait "$harness_pid" || true
+                exit 1
+              fi
+
+              if adb shell run-as "$PACKAGE_NAME" sh -c "[ -f '$READY_FLAG' ]" >/dev/null 2>&1; then
+                break
+              fi
+
+              if [ $elapsed -ge $timeout ]; then
+                echo "::error::Timed out waiting for screenshot harness readiness flag" >&2
+                cat "$HARNESS_LOG" >&2 || true
+                exit 1
+              fi
+
+              sleep 2
+              elapsed=$((elapsed + 2))
+            done
+          }
+
+          wait_for_harness
+
           adb shell settings put system accelerometer_rotation 0 || true
           adb shell settings put system user_rotation 0 || true
           adb shell cmd uimode night no || true
           adb shell settings put secure high_text_contrast_enabled 0 || true
           adb shell settings put secure accessibility_display_daltonizer_enabled 0 || true
-          sleep 10
+          sleep 5
 
           capture_set() {
             local label="$1"
@@ -897,6 +955,21 @@ jobs:
           capture_set "dark-portrait-standard" portrait yes 0 none 4
           capture_set "dark-landscape-accessibility" landscape yes 1 1 4
           capture_set "light-landscape-standard" landscape no 0 none 3
+
+          if ! adb shell run-as "$PACKAGE_NAME" sh -c "printf '' > '$DONE_FLAG'" >/dev/null 2>&1; then
+            echo "::error::Failed to signal screenshot harness completion" >&2
+            exit 1
+          fi
+
+          if ! wait "$harness_pid"; then
+            status=$?
+            echo "::error::Screenshot harness instrumentation reported failure" >&2
+            cat "$HARNESS_LOG" >&2 || true
+            exit $status
+          fi
+
+          trap - EXIT
+          finish_harness
 
           adb shell settings put system user_rotation 0 || true
           adb shell cmd uimode night no || true

--- a/app/src/androidTest/kotlin/com/novapdf/reader/ScreenshotHarnessTest.kt
+++ b/app/src/androidTest/kotlin/com/novapdf/reader/ScreenshotHarnessTest.kt
@@ -1,0 +1,134 @@
+package com.novapdf.reader
+
+import android.content.Context
+import android.net.Uri
+import androidx.lifecycle.Lifecycle
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.By
+import androidx.test.uiautomator.UiDevice
+import androidx.test.uiautomator.Until
+import androidx.work.WorkManager
+import java.io.File
+import java.util.Locale
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import org.junit.After
+import org.junit.Assume.assumeTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlin.text.Charsets
+
+@RunWith(AndroidJUnit4::class)
+class ScreenshotHarnessTest {
+
+    @get:Rule
+    val activityRule = ActivityScenarioRule(ReaderActivity::class.java)
+
+    private lateinit var device: UiDevice
+    private lateinit var appContext: Context
+    private lateinit var documentUri: Uri
+    private var harnessEnabled: Boolean = false
+
+    @Before
+    fun setUp() = runBlocking {
+        harnessEnabled = shouldRunHarness()
+        assumeTrue("Screenshot harness disabled", harnessEnabled)
+
+        device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+        appContext = ApplicationProvider.getApplicationContext()
+        documentUri = TestDocumentFixtures.installThousandPageDocument(appContext)
+        withContext(Dispatchers.IO) {
+            WorkManager.getInstance(appContext).cancelAllWork().result.get(5, TimeUnit.SECONDS)
+        }
+    }
+
+    @After
+    fun tearDown() = runBlocking {
+        if (!harnessEnabled) return@runBlocking
+        withContext(Dispatchers.IO) {
+            WorkManager.getInstance(appContext).cancelAllWork().result.get(5, TimeUnit.SECONDS)
+            cleanupFlags()
+        }
+    }
+
+    @Test
+    fun openThousandPageDocumentForScreenshots() = runBlocking {
+        val harnessActive = shouldRunHarness()
+        assumeTrue("Screenshot harness disabled", harnessActive)
+
+        openDocumentInViewer()
+        waitForScreenshotHandshake()
+    }
+
+    private suspend fun waitForScreenshotHandshake() {
+        withContext(Dispatchers.IO) {
+            val cacheDir = appContext.cacheDir
+                ?: throw IllegalStateException("Cache directory unavailable for screenshot handshake")
+            val readyFlag = File(cacheDir, SCREENSHOT_READY_FLAG)
+            val doneFlag = File(cacheDir, SCREENSHOT_DONE_FLAG)
+
+            if (doneFlag.exists() && !doneFlag.delete()) {
+                throw IllegalStateException("Unable to clear stale screenshot completion flag")
+            }
+
+            readyFlag.writeText("ready", Charsets.UTF_8)
+
+            val start = System.currentTimeMillis()
+            while (!doneFlag.exists()) {
+                if (!activityRule.scenario.state.isAtLeast(Lifecycle.State.STARTED)) {
+                    throw IllegalStateException("ReaderActivity unexpectedly stopped while waiting for screenshots")
+                }
+                if (System.currentTimeMillis() - start > TimeUnit.MINUTES.toMillis(5)) {
+                    throw IllegalStateException("Timed out waiting for host screenshot completion signal")
+                }
+                Thread.sleep(250)
+            }
+
+            if (!doneFlag.delete()) {
+                throw IllegalStateException("Unable to delete screenshot completion flag")
+            }
+            if (!readyFlag.delete()) {
+                throw IllegalStateException("Unable to delete screenshot readiness flag")
+            }
+        }
+    }
+
+    private fun cleanupFlags() {
+        val cacheDir = appContext.cacheDir ?: return
+        File(cacheDir, SCREENSHOT_READY_FLAG).delete()
+        File(cacheDir, SCREENSHOT_DONE_FLAG).delete()
+    }
+
+    private fun shouldRunHarness(): Boolean {
+        val argument = InstrumentationRegistry.getArguments().getString(HARNESS_ARGUMENT)
+        return argument?.lowercase(Locale.US) == "true"
+    }
+
+    private fun openDocumentInViewer() {
+        activityRule.scenario.onActivity { activity ->
+            activity.openDocumentForTest(documentUri)
+        }
+        val statusVisible = device.wait(
+            Until.hasObject(By.textContains("Adaptive Flow")),
+            UI_WAIT_TIMEOUT
+        )
+        if (!statusVisible) {
+            throw IllegalStateException("Adaptive Flow status chip did not appear after opening document")
+        }
+        device.waitForIdle()
+    }
+
+    private companion object {
+        private const val SCREENSHOT_READY_FLAG = "screenshot_ready.flag"
+        private const val SCREENSHOT_DONE_FLAG = "screenshot_done.flag"
+        private const val HARNESS_ARGUMENT = "runScreenshotHarness"
+        private const val UI_WAIT_TIMEOUT = 5_000L
+    }
+}


### PR DESCRIPTION
## Summary
- add an instrumentation-based screenshot harness that opens the thousand-page PDF and waits for host coordination
- update the CI screenshot step to launch the harness, wait for PDF readiness, and capture adb screencaps once the document is rendered

## Testing
- ./gradlew :app:compileDebugAndroidTestKotlin

------
https://chatgpt.com/codex/tasks/task_e_68dd04ead150832bafd080177f415dba