### PR TITLE
Throttle background work when UI is under load

### DIFF
--- a/app/src/main/kotlin/com/novapdf/reader/work/DocumentMaintenanceWorker.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/work/DocumentMaintenanceWorker.kt
@@ -20,6 +20,9 @@ class DocumentMaintenanceWorker(
 
     override suspend fun doWork(): Result {
         val app = applicationContext as? NovaPdfApp ?: return Result.failure()
+        if (app.adaptiveFlowManager.isUiUnderLoad()) {
+            return Result.retry()
+        }
         val annotationRepository = app.annotationRepository
         val bookmarkManager = app.bookmarkManager
 

--- a/app/src/test/kotlin/com/novapdf/reader/AdaptiveFlowManagerTest.kt
+++ b/app/src/test/kotlin/com/novapdf/reader/AdaptiveFlowManagerTest.kt
@@ -71,6 +71,7 @@ class AdaptiveFlowManagerTest {
         val jankyPreload = manager.preloadTargets.value
 
         assertTrue(jankyPreload.isEmpty())
+        assertTrue(manager.uiUnderLoad.value)
     }
 
     @Test
@@ -93,12 +94,14 @@ class AdaptiveFlowManagerTest {
         manager.trackPageChange(2, 10)
         advanceUntilIdle()
         assertTrue(manager.preloadTargets.value.isEmpty())
+        assertTrue(manager.uiUnderLoad.value)
 
         now += BuildConfig.ADAPTIVE_FLOW_PRELOAD_COOLDOWN_MS + 200
         manager.trackPageChange(3, 10)
         advanceUntilIdle()
 
         assertTrue(manager.preloadTargets.value.isNotEmpty())
+        assertTrue(!manager.uiUnderLoad.value)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- expose AdaptiveFlowManager load state so prefetch decisions can observe frame pacing
- gate PDF prefetch requests while the UI is marked as under load
- retry document maintenance work if the UI is currently under load and update tests for the new signal

## Testing
- ./gradlew --console=plain testDebugUnitTest *(fails: Unable to delete directory in compileDebugJavaWithJavac)*

------
https://chatgpt.com/codex/tasks/task_e_68dd0fdcf1e4832bb414f4c961b88010