### PR TITLE
Add instrumentation manifest for screenshot harness

### DIFF
--- a/app/src/androidTest/AndroidManifest.xml
+++ b/app/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,8 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <instrumentation
+        android:name="androidx.test.runner.AndroidJUnitRunner"
+        android:targetPackage="${applicationId}"
+        android:targetProcesses="${applicationId}"
+        android:functionalTest="false"
+        android:handleProfiling="false" />
+</manifest>


### PR DESCRIPTION
## Summary
- add an explicit androidTest manifest that registers the instrumentation runner so the screenshot harness can be discovered

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd3bafefb0832b81f2b3529c24592f