### PR TITLE
Fix instrumentation package to follow runtime app id

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -66,6 +66,7 @@ val baselineProfileProject = rootProject.findProject(":baselineprofile")
 
 android {
     namespace = "com.novapdf.reader"
+    testNamespace = "$resolvedApplicationId.test"
     compileSdk = 35
 
     defaultConfig {
@@ -77,6 +78,11 @@ android {
 
         vectorDrawables.useSupportLibrary = true
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        testApplicationId = "$resolvedApplicationId.test"
+        manifestPlaceholders += mapOf(
+            "novapdfAppId" to resolvedApplicationId,
+            "novapdfTestAppId" to "$resolvedApplicationId.test"
+        )
 
         buildConfigField("int", "LOW_END_MIN_PPM", "8")
         buildConfigField("int", "LOW_END_MAX_PPM", "90")

--- a/app/src/androidTest/AndroidManifest.xml
+++ b/app/src/androidTest/AndroidManifest.xml
@@ -1,8 +1,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <instrumentation
         android:name="androidx.test.runner.AndroidJUnitRunner"
-        android:targetPackage="${applicationId}"
-        android:targetProcesses="${applicationId}"
+        android:targetPackage="${novapdfAppId}"
+        android:targetProcesses="${novapdfAppId}"
         android:functionalTest="false"
-        android:handleProfiling="false" />
+        android:handleProfiling="false"
+        android:label="Tests for ${novapdfAppId}" />
 </manifest>


### PR DESCRIPTION
## Summary
- ensure the androidTest namespace and application id track the resolved application id used for builds
- update the instrumentation manifest placeholders so the runner targets the correct app package

## Testing
- NOVAPDF_APP_ID=com.example.custom ./gradlew :app:processDebugAndroidTestManifest --no-daemon

------
https://chatgpt.com/codex/tasks/task_e_68dd530f7d50832ba498cc0b4382fedc