### PR TITLE
Relocate font README out of Android resources

### DIFF
--- a/docs/fonts/README.md
+++ b/docs/fonts/README.md
@@ -1,6 +1,6 @@
 # Font Assets
 
-The Roboto Flex variable font (`roboto_flex_variable.ttf`) was downloaded from the official Google Fonts repository:
+The Roboto Flex variable font (`app/src/main/res/font/roboto_flex_variable.ttf`) was downloaded from the official Google Fonts repository:
 https://github.com/google/fonts/raw/main/ofl/robotoflex/RobotoFlex%5BGX,opsz,wdth,wght%5D.ttf
 
 The previous placeholder file contained an HTML download page, which caused runtime font loading failures during screenshot instrumentation tests.


### PR DESCRIPTION
## Summary
- move the Roboto Flex font README out of the Android resource directory into docs/fonts
- note the location of the variable font asset in the relocated README so documentation remains available

## Testing
- ./gradlew assembleDebug --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68dd6f28266c832bbeaae26d53bfcc8d