### PR TITLE
Prevent invalid docs in font resources

### DIFF
--- a/app/src/main/res/font/.gitignore
+++ b/app/src/main/res/font/.gitignore
@@ -1,0 +1,9 @@
+# Keep this directory limited to Android font resources.
+# Gradle's resource merger only accepts font XML or font binaries here.
+# Documentation belongs under docs/fonts/ instead.
+*
+!*.ttf
+!*.ttc
+!*.otf
+!*.xml
+!.gitignore

--- a/docs/fonts/README.md
+++ b/docs/fonts/README.md
@@ -4,3 +4,5 @@ The Roboto Flex variable font (`app/src/main/res/font/roboto_flex_variable.ttf`)
 https://github.com/google/fonts/raw/main/ofl/robotoflex/RobotoFlex%5BGX,opsz,wdth,wght%5D.ttf
 
 The previous placeholder file contained an HTML download page, which caused runtime font loading failures during screenshot instrumentation tests.
+
+> **Note:** Android's resource merger only accepts font binaries (`.ttf`, `.ttc`, `.otf`) or font family XML descriptors inside `app/src/main/res/font/`. Any documentation should live in this `docs/fonts/` directory to keep Gradle builds green.


### PR DESCRIPTION
## Summary
- add a .gitignore to `app/src/main/res/font` so only font assets with supported extensions are tracked
- document that font-related notes belong in `docs/fonts/` to avoid Gradle resource merger failures

## Testing
- ./gradlew testDebugUnitTest --info

------
https://chatgpt.com/codex/tasks/task_e_68dd71680c24832b842715677c159201