### PR TITLE
Ensure Roboto Flex font survives resource shrinking

### DIFF
--- a/app/src/main/res/values/keep.xml
+++ b/app/src/main/res/values/keep.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools"
+    tools:keep="@font/roboto_flex_variable" />


### PR DESCRIPTION
## Summary
- add a tools:keep hint so the Roboto Flex variable font is retained when resources are shrunk, preventing runtime font loading crashes

## Testing
- ./gradlew :app:lintDebug *(fails: existing NewApi lint violation in ReaderActivity)*

------
https://chatgpt.com/codex/tasks/task_e_68dd7b5cc478832b8839c538ba3077cb