### PR TITLE
Gracefully fall back when Roboto Flex font is unavailable

### DIFF
--- a/app/src/main/kotlin/com/novapdf/reader/ui/theme/Theme.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/ui/theme/Theme.kt
@@ -62,7 +62,7 @@ fun NovaPdfTheme(
 
     MaterialTheme(
         colorScheme = colorScheme,
-        typography = NovaPdfTypography,
+        typography = rememberNovaPdfTypography(),
         shapes = NovaPdfShapes,
         content = content
     )

--- a/app/src/main/kotlin/com/novapdf/reader/ui/theme/Type.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/ui/theme/Type.kt
@@ -1,10 +1,15 @@
 package com.novapdf.reader.ui.theme
 
+import android.util.Log
 import androidx.compose.material3.Typography
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
+import androidx.core.content.res.ResourcesCompat
 import com.novapdf.reader.R
 
 private val robotoFlexFamily = FontFamily(
@@ -30,22 +35,46 @@ private val robotoFlexFamily = FontFamily(
     )
 )
 
-val NovaPdfTypography = Typography().run {
+private val fallbackTypography = createNovaPdfTypography(FontFamily.SansSerif)
+
+@Composable
+fun rememberNovaPdfTypography(): Typography {
+    val context = LocalContext.current
+    return remember(context) {
+        val fontFamily = runCatching {
+            ResourcesCompat.getFont(context, R.font.roboto_flex_variable)
+            robotoFlexFamily
+        }.getOrElse { error ->
+            Log.w(TAG, "Unable to load Roboto Flex font; falling back to platform sans-serif.", error)
+            FontFamily.SansSerif
+        }
+
+        if (fontFamily == FontFamily.SansSerif) {
+            fallbackTypography
+        } else {
+            createNovaPdfTypography(fontFamily)
+        }
+    }
+}
+
+private fun createNovaPdfTypography(fontFamily: FontFamily): Typography = Typography().run {
     copy(
-        displayLarge = displayLarge.copy(fontFamily = robotoFlexFamily),
-        displayMedium = displayMedium.copy(fontFamily = robotoFlexFamily),
-        displaySmall = displaySmall.copy(fontFamily = robotoFlexFamily),
-        headlineLarge = headlineLarge.copy(fontFamily = robotoFlexFamily),
-        headlineMedium = headlineMedium.copy(fontFamily = robotoFlexFamily),
-        headlineSmall = headlineSmall.copy(fontFamily = robotoFlexFamily),
-        titleLarge = titleLarge.copy(fontFamily = robotoFlexFamily, fontWeight = FontWeight.SemiBold),
-        titleMedium = titleMedium.copy(fontFamily = robotoFlexFamily, fontWeight = FontWeight.Medium),
-        titleSmall = titleSmall.copy(fontFamily = robotoFlexFamily, fontWeight = FontWeight.Medium),
-        bodyLarge = bodyLarge.copy(fontFamily = robotoFlexFamily, lineHeight = 24.sp),
-        bodyMedium = bodyMedium.copy(fontFamily = robotoFlexFamily),
-        bodySmall = bodySmall.copy(fontFamily = robotoFlexFamily),
-        labelLarge = labelLarge.copy(fontFamily = robotoFlexFamily, fontWeight = FontWeight.Medium),
-        labelMedium = labelMedium.copy(fontFamily = robotoFlexFamily),
-        labelSmall = labelSmall.copy(fontFamily = robotoFlexFamily)
+        displayLarge = displayLarge.copy(fontFamily = fontFamily),
+        displayMedium = displayMedium.copy(fontFamily = fontFamily),
+        displaySmall = displaySmall.copy(fontFamily = fontFamily),
+        headlineLarge = headlineLarge.copy(fontFamily = fontFamily),
+        headlineMedium = headlineMedium.copy(fontFamily = fontFamily),
+        headlineSmall = headlineSmall.copy(fontFamily = fontFamily),
+        titleLarge = titleLarge.copy(fontFamily = fontFamily, fontWeight = FontWeight.SemiBold),
+        titleMedium = titleMedium.copy(fontFamily = fontFamily, fontWeight = FontWeight.Medium),
+        titleSmall = titleSmall.copy(fontFamily = fontFamily, fontWeight = FontWeight.Medium),
+        bodyLarge = bodyLarge.copy(fontFamily = fontFamily, lineHeight = 24.sp),
+        bodyMedium = bodyMedium.copy(fontFamily = fontFamily),
+        bodySmall = bodySmall.copy(fontFamily = fontFamily),
+        labelLarge = labelLarge.copy(fontFamily = fontFamily, fontWeight = FontWeight.Medium),
+        labelMedium = labelMedium.copy(fontFamily = fontFamily),
+        labelSmall = labelSmall.copy(fontFamily = fontFamily)
     )
 }
+
+private const val TAG = "NovaPdfTypography"


### PR DESCRIPTION
## Summary
- add a composable typography provider that verifies the Roboto Flex font can be resolved and logs a fallback when it cannot
- update the theme to use the new typography helper so tests avoid crashing when fonts are missing

## Testing
- ./gradlew :app:compileDebugKotlin --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68dd856f1574832bb375c11a28474874