### PR TITLE
Fix thousand-page fixture to include valid content stream

### DIFF
--- a/app/src/androidTest/kotlin/com/novapdf/reader/TestDocumentFixtures.kt
+++ b/app/src/androidTest/kotlin/com/novapdf/reader/TestDocumentFixtures.kt
@@ -114,8 +114,12 @@ internal object TestDocumentFixtures {
                 }
             }
 
+            val sharedStream = "q\nQ\n"
+            val sharedStreamBytes = sharedStream.toByteArray(Charsets.US_ASCII)
             beginObject(sharedContentObject) {
-                write("<< /Length 0 >>\nstream\n\nendstream")
+                write("<< /Length ${sharedStreamBytes.size} >>\nstream\n")
+                write(sharedStream)
+                write("endstream")
             }
 
             val startXref = bytesWritten


### PR DESCRIPTION
## Summary
- ensure the thousand-page PDF test fixture writes a non-empty content stream
- update the stream length metadata to match the new content so Pdfium can open the file reliably

## Testing
- ./gradlew test --console=plain --no-build-cache --rerun-tasks

------
https://chatgpt.com/codex/tasks/task_e_68de0faef69c832ba78660b3dfeda0a5