### PR TITLE
Disable profile installer during instrumentation

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,6 +21,10 @@
         android:roundIcon="@drawable/ic_pdf"
         android:supportsRtl="true"
         android:theme="@style/Theme.NovaPDFReader">
+        <meta-data
+            android:name="androidx.profileinstaller.PROFILE_INSTALLER_ENABLED"
+            android:value="false" />
+
         <activity
             android:name="com.novapdf.reader.ReaderActivity"
             android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"


### PR DESCRIPTION
## Summary
- disable the ProfileInstaller runtime initializer so instrumentation can run without crashing on dead system exceptions

## Testing
- ./gradlew --no-daemon --console=plain --version

------
https://chatgpt.com/codex/tasks/task_e_68de40ae7dc0832b9d52efcc0effd689