### PR TITLE
Avoid OOM in screenshot harness by streaming PDF writer

### DIFF
--- a/app/src/androidTest/kotlin/com/novapdf/reader/TestDocumentFixtures.kt
+++ b/app/src/androidTest/kotlin/com/novapdf/reader/TestDocumentFixtures.kt
@@ -3,11 +3,6 @@ package com.novapdf.reader
 import android.content.Context
 import androidx.core.net.toUri
 import androidx.test.platform.app.InstrumentationRegistry
-import android.graphics.Color
-import android.graphics.Paint
-import android.graphics.Typeface
-import android.graphics.pdf.PdfDocument
-import java.io.BufferedOutputStream
 import java.io.File
 import java.io.IOException
 import java.net.HttpURLConnection
@@ -118,59 +113,13 @@ internal object TestDocumentFixtures {
             }
         } ?: throw IOException("Missing cache directory for thousand-page PDF")
 
-        val pdfDocument = PdfDocument()
-        val titlePaint = Paint().apply {
-            color = Color.BLACK
-            textSize = 24f
-            isAntiAlias = true
-            typeface = Typeface.MONOSPACE
-        }
-        val subtitlePaint = Paint(titlePaint).apply {
-            textSize = 14f
-            color = Color.DKGRAY
-        }
-
         try {
-            repeat(THOUSAND_PAGE_COUNT) { index ->
-                val pageNumber = index + 1
-                val pageInfo = PdfDocument.PageInfo.Builder(612, 792, pageNumber).create()
-                val page = pdfDocument.startPage(pageInfo)
-                val canvas = page.canvas
-
-                canvas.drawColor(Color.WHITE)
-                canvas.drawText(
-                    "Adaptive Flow benchmark page $pageNumber",
-                    72f,
-                    108f,
-                    titlePaint
-                )
-                canvas.drawText(
-                    "Total pages: $THOUSAND_PAGE_COUNT",
-                    72f,
-                    156f,
-                    subtitlePaint
-                )
-                canvas.drawText(
-                    "Generated for screenshot harness",
-                    72f,
-                    186f,
-                    subtitlePaint
-                )
-
-                pdfDocument.finishPage(page)
-            }
-
             destination.outputStream().use { outputStream ->
-                BufferedOutputStream(outputStream).use { buffered ->
-                    pdfDocument.writeTo(buffered)
-                    buffered.flush()
-                }
+                ThousandPagePdfWriter(THOUSAND_PAGE_COUNT).writeTo(outputStream)
             }
         } catch (error: IOException) {
             destination.delete()
             throw error
-        } finally {
-            pdfDocument.close()
         }
 
         if (destination.length() <= 0L) {

--- a/app/src/androidTest/kotlin/com/novapdf/reader/ThousandPagePdfWriter.kt
+++ b/app/src/androidTest/kotlin/com/novapdf/reader/ThousandPagePdfWriter.kt
@@ -1,0 +1,175 @@
+package com.novapdf.reader
+
+import java.io.BufferedOutputStream
+import java.io.Closeable
+import java.io.IOException
+import java.io.OutputStream
+import java.nio.charset.StandardCharsets
+import java.util.Locale
+
+/**
+ * Generates a deterministic thousand-page PDF without relying on [android.graphics.pdf.PdfDocument].
+ *
+ * The rendering APIs allocate an in-memory representation for the entire document, which can trigger
+ * out-of-memory crashes on lower-resource emulators. This writer produces an equivalent stress document
+ * directly in the PDF format so that it can be streamed to disk and opened safely in tests.
+ */
+internal class ThousandPagePdfWriter(
+    private val pageCount: Int,
+    private val pageWidth: Int = 612,
+    private val pageHeight: Int = 792,
+) {
+
+    @Throws(IOException::class)
+    fun writeTo(stream: OutputStream) {
+        CountingOutputStream(BufferedOutputStream(stream)).use { output ->
+            PdfStreamEncoder(output, pageCount, pageWidth, pageHeight).write()
+            output.flush()
+        }
+    }
+
+    private class CountingOutputStream(
+        private val delegate: OutputStream
+    ) : OutputStream(), Closeable {
+        var bytesWritten: Long = 0
+            private set
+
+        override fun write(b: Int) {
+            delegate.write(b)
+            bytesWritten++
+        }
+
+        override fun write(b: ByteArray) {
+            delegate.write(b)
+            bytesWritten += b.size
+        }
+
+        override fun write(b: ByteArray, off: Int, len: Int) {
+            delegate.write(b, off, len)
+            bytesWritten += len
+        }
+
+        override fun flush() {
+            delegate.flush()
+        }
+
+        override fun close() {
+            delegate.close()
+        }
+    }
+
+    private class PdfStreamEncoder(
+        private val output: CountingOutputStream,
+        private val pageCount: Int,
+        private val pageWidth: Int,
+        private val pageHeight: Int,
+    ) {
+        private val fontObjectNumber = 3 + pageCount * 2
+        private val totalObjects = fontObjectNumber
+        private val objectOffsets = LongArray(totalObjects + 1)
+
+        @Throws(IOException::class)
+        fun write() {
+            writeAscii("%PDF-1.4\n")
+
+            writeCatalog()
+            writePages()
+            writePageObjects()
+            writeContentStreams()
+            writeFontObject()
+
+            val startXref = output.bytesWritten
+            writeAscii("xref\n")
+            writeAscii("0 ${totalObjects + 1}\n")
+            writeAscii("0000000000 65535 f \n")
+            for (index in 1..totalObjects) {
+                val offset = objectOffsets[index]
+                writeAscii(String.format(Locale.US, "%010d 00000 n \n", offset))
+            }
+            writeAscii("trailer\n")
+            writeAscii("<< /Size ${totalObjects + 1} /Root 1 0 R >>\n")
+            writeAscii("startxref\n")
+            writeAscii("$startXref\n")
+            writeAscii("%%EOF\n")
+        }
+
+        private fun writeCatalog() {
+            startObject(1)
+            writeAscii("<< /Type /Catalog /Pages 2 0 R >>\n")
+            endObject()
+        }
+
+        private fun writePages() {
+            startObject(2)
+            writeAscii("<< /Type /Pages /Count $pageCount /Kids [")
+            for (pageIndex in 0 until pageCount) {
+                val pageObjectNumber = pageObjectNumber(pageIndex)
+                writeAscii("$pageObjectNumber 0 R ")
+            }
+            writeAscii("] >>\n")
+            endObject()
+        }
+
+        private fun writePageObjects() {
+            for (pageIndex in 0 until pageCount) {
+                val pageNumber = pageIndex + 1
+                val pageObjectNumber = pageObjectNumber(pageIndex)
+                val contentObjectNumber = contentObjectNumber(pageIndex)
+                startObject(pageObjectNumber)
+                writeAscii(
+                    "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 $pageWidth $pageHeight] " +
+                        "/Contents $contentObjectNumber 0 R /Resources << /Font << /F1 $fontObjectNumber 0 R >> >> >>\n"
+                )
+                endObject()
+            }
+        }
+
+        private fun writeContentStreams() {
+            for (pageIndex in 0 until pageCount) {
+                val contentObjectNumber = contentObjectNumber(pageIndex)
+                val pageNumber = pageIndex + 1
+                val contentBytes = buildPageContent(pageNumber)
+                startObject(contentObjectNumber)
+                writeAscii("<< /Length ${contentBytes.size} >>\n")
+                writeAscii("stream\n")
+                output.write(contentBytes)
+                writeAscii("\nendstream\n")
+                endObject()
+            }
+        }
+
+        private fun writeFontObject() {
+            startObject(fontObjectNumber)
+            writeAscii("<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\n")
+            endObject()
+        }
+
+        private fun startObject(number: Int) {
+            objectOffsets[number] = output.bytesWritten
+            writeAscii("$number 0 obj\n")
+        }
+
+        private fun endObject() {
+            writeAscii("endobj\n")
+        }
+
+        private fun pageObjectNumber(index: Int): Int = 3 + index
+
+        private fun contentObjectNumber(index: Int): Int = 3 + pageCount + index
+
+        private fun buildPageContent(pageNumber: Int): ByteArray {
+            val content = buildString {
+                append("BT /F1 24 Tf 72 720 Td (Adaptive Flow benchmark page $pageNumber) Tj ET\n")
+                append("BT /F1 14 Tf 72 680 Td (Total pages: $pageCount) Tj ET\n")
+                append("BT /F1 14 Tf 72 650 Td (Generated for screenshot harness) Tj ET\n")
+                append("BT /F1 12 Tf 72 620 Td (Page index: ${pageNumber - 1}) Tj ET\n")
+            }
+            return content.toByteArray(StandardCharsets.US_ASCII)
+        }
+
+        private fun writeAscii(value: String) {
+            output.write(value.toByteArray(StandardCharsets.US_ASCII))
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- replace the PdfDocument-based thousand-page generator with a lightweight streaming writer to avoid memory spikes during instrumentation
- update the screenshot fixture to use the new writer while keeping download support

## Testing
- ./gradlew testDebugUnitTest --no-daemon --console=plain --max-workers=1 *(fails: Gradle incremental compiler cache became corrupted after repeated aborted builds)*

------
https://chatgpt.com/codex/tasks/task_e_68de7d6113c8832b8bba80372e4a03a2