### PR TITLE
Ensure screenshot harness uses credential-protected cache

### DIFF
--- a/app/src/androidTest/kotlin/com/novapdf/reader/ScreenshotHarnessTest.kt
+++ b/app/src/androidTest/kotlin/com/novapdf/reader/ScreenshotHarnessTest.kt
@@ -2,6 +2,7 @@ package com.novapdf.reader
 
 import android.content.Context
 import android.net.Uri
+import android.os.Build
 import android.os.SystemClock
 import android.util.Log
 import androidx.lifecycle.Lifecycle
@@ -103,7 +104,14 @@ class ScreenshotHarnessTest {
     }
 
     private fun resolveHandshakeCacheDir(): File {
-        val contextCache = InstrumentationRegistry.getInstrumentation().context.cacheDir
+        val instrumentationContext = InstrumentationRegistry.getInstrumentation().context
+        val credentialContext = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            instrumentationContext.createCredentialProtectedStorageContext()
+        } else {
+            instrumentationContext
+        }
+
+        val contextCache = credentialContext.cacheDir
             ?: throw IllegalStateException("Instrumentation cache directory unavailable for screenshot handshake")
         if (!contextCache.exists() && !contextCache.mkdirs()) {
             throw IllegalStateException("Unable to create instrumentation cache directory for screenshot handshake")


### PR DESCRIPTION
## Summary
- ensure the screenshot harness resolves its handshake cache directory from credential-protected storage so host scripts can observe readiness flags

## Testing
- not run (Android instrumentation tests require device/emulator)


------
https://chatgpt.com/codex/tasks/task_e_68df3c602454832b9a030f42720c16a1