### PR TITLE
Ensure screenshot harness instrumentation is debuggable

### DIFF
--- a/app/src/androidTest/AndroidManifest.xml
+++ b/app/src/androidTest/AndroidManifest.xml
@@ -1,4 +1,10 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <application
+        android:debuggable="true"
+        tools:replace="android:debuggable" />
+
     <instrumentation
         android:name="androidx.test.runner.AndroidJUnitRunner"
         android:targetPackage="${novapdfAppId}"


### PR DESCRIPTION
## Summary
- mark the androidTest application as debuggable so the screenshot harness can use `run-as`

## Testing
- not run (host-only change)


------
https://chatgpt.com/codex/tasks/task_e_68df555e4250832bae05ec427053763f