### PR TITLE
Fix screenshot harness test arguments usage

### DIFF
--- a/app/src/androidTest/kotlin/com/novapdf/reader/ScreenshotHarnessTest.kt
+++ b/app/src/androidTest/kotlin/com/novapdf/reader/ScreenshotHarnessTest.kt
@@ -193,7 +193,7 @@ class ScreenshotHarnessTest {
 
     private fun resolveTestPackageName(): String {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
-        val arguments = instrumentation.arguments
+        val arguments = InstrumentationRegistry.getArguments()
         val targetInstrumentation = arguments.getString("targetInstrumentation")
 
         val parsed = targetInstrumentation


### PR DESCRIPTION
## Summary
- use InstrumentationRegistry.getArguments() when reading instrumentation extras in the screenshot harness test to avoid unresolved reference errors

## Testing
- ./gradlew :app:compileDebugAndroidTestKotlin --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68df850efbd0832b80c9e3f362fcb7e1