### PR TITLE
Fix thousand-page PDF cross-reference entries

### DIFF
--- a/app/src/androidTest/kotlin/com/novapdf/reader/ThousandPagePdfWriter.kt
+++ b/app/src/androidTest/kotlin/com/novapdf/reader/ThousandPagePdfWriter.kt
@@ -83,10 +83,10 @@ internal class ThousandPagePdfWriter(
             val startXref = output.bytesWritten
             writeAscii("xref\r\n")
             writeAscii("0 ${totalObjects + 1}\r\n")
-            writeAscii("0000000000 65535 f \r\n")
+            writeAscii("0000000000 65535 f\r\n")
             for (index in 1..totalObjects) {
                 val offset = objectOffsets[index]
-                writeAscii(String.format(Locale.US, "%010d 00000 n \r\n", offset))
+                writeAscii(String.format(Locale.US, "%010d 00000 n\r\n", offset))
             }
             writeAscii("trailer\r\n")
             writeAscii("<< /Size ${totalObjects + 1} /Root 1 0 R >>\r\n")


### PR DESCRIPTION
## Summary
- remove trailing spaces from the thousand-page PDF writer cross-reference entries so the generated document has valid offsets

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68df910380ec832bbe767433a10e3cfc