### PR TITLE
Harden thousand-page PDF fixture generation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -168,6 +168,11 @@ android {
         execution = "ANDROIDX_TEST_ORCHESTRATOR"
     }
 
+    sourceSets {
+        getByName("test").java.srcDir("src/sharedTest/kotlin")
+        getByName("androidTest").java.srcDir("src/sharedTest/kotlin")
+    }
+
     adbOptions {
         installOptions.add("-t")
 
@@ -594,6 +599,7 @@ dependencies {
     testImplementation("androidx.test:core:1.5.0")
     testImplementation("androidx.room:room-testing:2.6.1")
     testImplementation("androidx.work:work-testing:2.9.0")
+    testImplementation("org.apache.pdfbox:pdfbox:2.0.31")
 
     androidTestImplementation("androidx.test.ext:junit:1.2.1")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")

--- a/app/src/sharedTest/kotlin/com/novapdf/reader/ThousandPagePdfWriter.kt
+++ b/app/src/sharedTest/kotlin/com/novapdf/reader/ThousandPagePdfWriter.kt
@@ -70,9 +70,9 @@ internal class ThousandPagePdfWriter(
 
         @Throws(IOException::class)
         fun write() {
-            writeAscii("%PDF-1.4\r\n")
+            writeAscii("%PDF-1.4\n")
             // Indicate that the file may contain binary data per the PDF specification.
-            writeAscii("%\u00E2\u00E3\u00CF\u00D3\r\n")
+            writeAscii("%\u00E2\u00E3\u00CF\u00D3\n")
 
             writeCatalog()
             writePages()
@@ -81,34 +81,34 @@ internal class ThousandPagePdfWriter(
             writeFontObject()
 
             val startXref = output.bytesWritten
-            writeAscii("xref\r\n")
-            writeAscii("0 ${totalObjects + 1}\r\n")
-            writeAscii("0000000000 65535 f\r\n")
+            writeAscii("xref\n")
+            writeAscii("0 ${totalObjects + 1}\n")
+            writeAscii("0000000000 65535 f\n")
             for (index in 1..totalObjects) {
                 val offset = objectOffsets[index]
-                writeAscii(String.format(Locale.US, "%010d 00000 n\r\n", offset))
+                writeAscii(String.format(Locale.US, "%010d 00000 n\n", offset))
             }
-            writeAscii("trailer\r\n")
-            writeAscii("<< /Size ${totalObjects + 1} /Root 1 0 R >>\r\n")
-            writeAscii("startxref\r\n")
-            writeAscii("$startXref\r\n")
-            writeAscii("%%EOF\r\n")
+            writeAscii("trailer\n")
+            writeAscii("<< /Size ${totalObjects + 1} /Root 1 0 R >>\n")
+            writeAscii("startxref\n")
+            writeAscii("$startXref\n")
+            writeAscii("%%EOF\n")
         }
 
         private fun writeCatalog() {
             startObject(1)
-            writeAscii("<< /Type /Catalog /Pages 2 0 R >>\r\n")
+            writeAscii("<< /Type /Catalog /Pages 2 0 R >>\n")
             endObject()
         }
 
         private fun writePages() {
             startObject(2)
-            writeAscii("<< /Type /Pages /Count $pageCount /Kids [\r\n")
+            writeAscii("<< /Type /Pages /Count $pageCount /Kids [\n")
             for (pageIndex in 0 until pageCount) {
                 val pageObjectNumber = pageObjectNumber(pageIndex)
-                writeAscii("$pageObjectNumber 0 R\r\n")
+                writeAscii("$pageObjectNumber 0 R\n")
             }
-            writeAscii("] >>\r\n")
+            writeAscii("] >>\n")
             endObject()
         }
 
@@ -119,7 +119,7 @@ internal class ThousandPagePdfWriter(
                 startObject(pageObjectNumber)
                 writeAscii(
                     "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 $pageWidth $pageHeight] " +
-                        "/Contents $contentObjectNumber 0 R /Resources << /Font << /F1 $fontObjectNumber 0 R >> >> >>\r\n"
+                        "/Contents $contentObjectNumber 0 R /Resources << /Font << /F1 $fontObjectNumber 0 R >> >> >>\n"
                 )
                 endObject()
             }
@@ -130,27 +130,27 @@ internal class ThousandPagePdfWriter(
                 val contentObjectNumber = contentObjectNumber(pageIndex)
                 val contentBytes = buildPageContent(pageIndex + 1)
                 startObject(contentObjectNumber)
-                writeAscii("<< /Length ${contentBytes.size} >>\r\n")
-                writeAscii("stream\r\n")
+                writeAscii("<< /Length ${contentBytes.size} >>\n")
+                writeAscii("stream\n")
                 output.write(contentBytes)
-                writeAscii("\r\nendstream\r\n")
+                writeAscii("\nendstream\n")
                 endObject()
             }
         }
 
         private fun writeFontObject() {
             startObject(fontObjectNumber)
-            writeAscii("<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\r\n")
+            writeAscii("<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\n")
             endObject()
         }
 
         private fun startObject(number: Int) {
             objectOffsets[number] = output.bytesWritten
-            writeAscii("$number 0 obj\r\n")
+            writeAscii("$number 0 obj\n")
         }
 
         private fun endObject() {
-            writeAscii("endobj\r\n")
+            writeAscii("endobj\n")
         }
 
         private fun pageObjectNumber(index: Int): Int = 3 + index
@@ -159,10 +159,10 @@ internal class ThousandPagePdfWriter(
 
         private fun buildPageContent(pageNumber: Int): ByteArray {
             val content = buildString {
-                append("BT /F1 24 Tf 72 720 Td (Adaptive Flow benchmark page $pageNumber) Tj ET\r\n")
-                append("BT /F1 14 Tf 72 680 Td (Total pages: $pageCount) Tj ET\r\n")
-                append("BT /F1 14 Tf 72 650 Td (Generated for screenshot harness) Tj ET\r\n")
-                append("BT /F1 12 Tf 72 620 Td (Page index: ${pageNumber - 1}) Tj ET\r\n")
+                append("BT /F1 24 Tf 72 720 Td (Adaptive Flow benchmark page $pageNumber) Tj ET\n")
+                append("BT /F1 14 Tf 72 680 Td (Total pages: $pageCount) Tj ET\n")
+                append("BT /F1 14 Tf 72 650 Td (Generated for screenshot harness) Tj ET\n")
+                append("BT /F1 12 Tf 72 620 Td (Page index: ${pageNumber - 1}) Tj ET\n")
             }
             return content.toByteArray(StandardCharsets.US_ASCII)
         }

--- a/app/src/test/kotlin/com/novapdf/reader/ThousandPagePdfWriterTest.kt
+++ b/app/src/test/kotlin/com/novapdf/reader/ThousandPagePdfWriterTest.kt
@@ -1,0 +1,23 @@
+package com.novapdf.reader
+
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import org.apache.pdfbox.pdmodel.PDDocument
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class ThousandPagePdfWriterTest {
+
+    @Test
+    fun `generated thousand page document is readable by pdfbox`() {
+        val output = ByteArrayOutputStream()
+        ThousandPagePdfWriter(1_000).writeTo(output)
+        val bytes = output.toByteArray()
+        require(bytes.isNotEmpty()) { "writer produced empty pdf" }
+        assertTrue(bytes.size < 10_000_000) { "expected compact fixture, size=${bytes.size}" }
+        PDDocument.load(ByteArrayInputStream(bytes)).use { document ->
+            assertEquals(1_000, document.numberOfPages)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- share the thousand-page PDF writer between unit and instrumentation sources via a sharedTest directory
- normalize the generated PDF stream to Unix newlines and add a pdfbox-backed unit test that verifies the fixture size and page count
- add Apache PDFBox as a unit test dependency to exercise the writer on the JVM

## Testing
- ./gradlew :app:testDebugUnitTest --tests "com.novapdf.reader.ThousandPagePdfWriterTest" --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68dfa03b98fc832b89c1e14bbba37977