### PR TITLE
Load thousand-page fixture from configurable remote

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -41,6 +41,9 @@ fun Project.resolveReleaseKeystore(defaultPath: String = "signing/release.keysto
     return candidate
 }
 
+fun String.asJavaStringLiteral(): String =
+    replace("\\", "\\\\").replace("\"", "\\\"")
+
 inline fun <reified T : Task> TaskContainer.namedOrNull(name: String): TaskProvider<T>? =
     try {
         named(name, T::class.java)
@@ -63,6 +66,11 @@ val resolvedApplicationId = (findProperty("NOVAPDF_APP_ID") as? String)
     ?: "com.novapdf.reader"
 
 val baselineProfileProject = rootProject.findProject(":baselineprofile")
+
+val thousandPageFixtureUrlProvider = providers
+    .environmentVariable("THOUSAND_PAGE_FIXTURE_URL")
+    .orElse(providers.gradleProperty("thousandPageFixtureUrl"))
+    .orElse("")
 
 android {
     namespace = "com.novapdf.reader"
@@ -90,6 +98,12 @@ android {
         buildConfigField("int", "HIGH_END_MAX_PPM", "210")
         buildConfigField("float", "ADAPTIVE_FLOW_JANK_FRAME_THRESHOLD_MS", "16.0f")
         buildConfigField("long", "ADAPTIVE_FLOW_PRELOAD_COOLDOWN_MS", "750L")
+        val thousandPageFixtureUrl = thousandPageFixtureUrlProvider.getOrElse("")
+        buildConfigField(
+            "String",
+            "THOUSAND_PAGE_FIXTURE_URL",
+            "\"${thousandPageFixtureUrl.asJavaStringLiteral()}\""
+        )
 
     }
 

--- a/app/src/androidTest/kotlin/com/novapdf/reader/TestDocumentFixtures.kt
+++ b/app/src/androidTest/kotlin/com/novapdf/reader/TestDocumentFixtures.kt
@@ -3,6 +3,7 @@ package com.novapdf.reader
 import android.content.Context
 import androidx.core.net.toUri
 import androidx.test.platform.app.InstrumentationRegistry
+import com.novapdf.reader.BuildConfig
 import java.io.File
 import java.io.IOException
 import java.net.HttpURLConnection
@@ -14,6 +15,8 @@ internal object TestDocumentFixtures {
     private const val THOUSAND_PAGE_CACHE = "stress-thousand-pages.pdf"
     private const val THOUSAND_PAGE_URL_ARG = "thousandPagePdfUrl"
     private const val THOUSAND_PAGE_COUNT = 1_000
+    private val DEFAULT_THOUSAND_PAGE_URL = BuildConfig.THOUSAND_PAGE_FIXTURE_URL
+        .takeIf { it.isNotBlank() }
 
     suspend fun installThousandPageDocument(context: Context): android.net.Uri =
         withContext(Dispatchers.IO) {
@@ -48,8 +51,8 @@ internal object TestDocumentFixtures {
         }
 
         try {
-            val downloaded = tryDownloadThousandPagePdf(tempFile)
-            if (!downloaded) {
+            val preparedFromNetwork = tryDownloadThousandPagePdf(tempFile)
+            if (!preparedFromNetwork) {
                 writeThousandPagePdf(tempFile)
             }
         } catch (error: IOException) {
@@ -70,6 +73,7 @@ internal object TestDocumentFixtures {
     private fun tryDownloadThousandPagePdf(destination: File): Boolean {
         val url = InstrumentationRegistry.getArguments().getString(THOUSAND_PAGE_URL_ARG)
             ?.takeIf { it.isNotBlank() }
+            ?: DEFAULT_THOUSAND_PAGE_URL
             ?: return false
 
         val connection = URL(url).openConnection() as? HttpURLConnection ?: return false


### PR DESCRIPTION
## Summary
- remove the bundled thousand-page PDF fixture from the androidTest assets
- allow the screenshot harness to download the thousand-page document via instrumentation argument or a configured S3 URL
- add Gradle configuration to surface the fixture URL from environment variables or Gradle properties into BuildConfig

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dfac605734832ba18d1370f4f39986