### PR TITLE
Improve screenshot harness cache directory fallback

### DIFF
--- a/app/src/androidTest/kotlin/com/novapdf/reader/ScreenshotHarnessTest.kt
+++ b/app/src/androidTest/kotlin/com/novapdf/reader/ScreenshotHarnessTest.kt
@@ -151,13 +151,26 @@ class ScreenshotHarnessTest {
             }
             .getOrNull()
 
-        val cacheDir = testCacheDir ?: instrumentation.context.credentialProtectedStorageContext().cacheDir
-            ?: throw IllegalStateException("Instrumentation cache directory unavailable for screenshot handshake")
+        val cacheDir = testCacheDir
+            ?: instrumentation.context.credentialProtectedStorageContext().cacheDir
+            ?: instrumentation.context.cacheDir
+            ?: deriveCacheDirFromFilesDir(instrumentation.context.filesDir)
+            ?: throw IllegalStateException(
+                "Instrumentation cache directory unavailable for screenshot handshake"
+            )
 
         if (!cacheDir.exists() && !cacheDir.mkdirs()) {
             throw IllegalStateException("Unable to create cache directory for screenshot handshake at ${cacheDir.absolutePath}")
         }
         return cacheDir
+    }
+
+    private fun deriveCacheDirFromFilesDir(filesDir: File?): File? {
+        if (filesDir == null) {
+            return null
+        }
+        val parent = filesDir.parentFile ?: return null
+        return File(parent, "cache")
     }
 
     private fun findTestPackageCacheDir(testPackageName: String): File {


### PR DESCRIPTION
## Summary
- add additional fallbacks when locating the instrumentation cache directory for the screenshot harness
- ensure the harness can derive a cache directory from the test package files directory when other lookups fail

## Testing
- ./gradlew clean test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68dfd657cd50832bb5f457c47381d93b