### PR TITLE
Handle stale screenshot completion flags gracefully

### DIFF
--- a/app/src/androidTest/kotlin/com/novapdf/reader/ScreenshotHarnessTest.kt
+++ b/app/src/androidTest/kotlin/com/novapdf/reader/ScreenshotHarnessTest.kt
@@ -76,7 +76,11 @@ class ScreenshotHarnessTest {
         val doneFlag = File(handshakeCacheDir, SCREENSHOT_DONE_FLAG)
 
         if (!withContext(Dispatchers.IO) { clearFlag(doneFlag) }) {
-            throw IllegalStateException("Unable to clear stale screenshot completion flag")
+            Log.w(
+                TAG,
+                "Unable to clear stale screenshot completion flag at ${doneFlag.absolutePath}; " +
+                    "continuing with existing flag"
+            )
         }
 
         withContext(Dispatchers.IO) { writeHandshakeFlag(readyFlag, "ready") }


### PR DESCRIPTION
## Summary
- avoid aborting the screenshot harness when a stale done flag cannot be deleted
- log the situation and continue so the instrumentation can still report readiness

## Testing
- ⚠️ not run (instrumentation tests require a connected device in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68dff9f7f92c832bb5b35b1db4f3a67d