### PR TITLE
Refine logcat crash detection

### DIFF
--- a/tools/check_logcat_for_crashes.py
+++ b/tools/check_logcat_for_crashes.py
@@ -26,7 +26,10 @@ def _build_crash_signatures(package_name: str) -> List[Tuple[Pattern[str], str]]
             f"Detected fatal crash in {package_name} during instrumentation tests",
         ),
         (
-            re.compile(r"E AndroidRuntime: FATAL EXCEPTION"),
+            re.compile(
+                rf"E AndroidRuntime: FATAL EXCEPTION[\s\S]+?Process:\s+{escaped}",
+                re.MULTILINE,
+            ),
             "AndroidRuntime reported a fatal exception while instrumentation tests were running",
         ),
         (

--- a/tools/test_check_logcat_for_crashes.py
+++ b/tools/test_check_logcat_for_crashes.py
@@ -1,0 +1,33 @@
+import unittest
+
+from tools import check_logcat_for_crashes
+
+
+class CrashSignatureTests(unittest.TestCase):
+    PACKAGE = "com.example.app"
+
+    def setUp(self):
+        self.signatures = check_logcat_for_crashes._build_crash_signatures(self.PACKAGE)
+
+    def _find_issues(self, log_text: str):
+        return check_logcat_for_crashes._find_issues(log_text, self.signatures)
+
+    def test_androidruntime_fatal_exception_other_process_ignored(self):
+        log = """E AndroidRuntime: FATAL EXCEPTION: main\nProcess: com.other.app, PID: 1234\n"""
+        issues = self._find_issues(log)
+        self.assertNotIn(
+            "AndroidRuntime reported a fatal exception while instrumentation tests were running",
+            issues,
+        )
+
+    def test_androidruntime_fatal_exception_for_package_detected(self):
+        log = """E AndroidRuntime: FATAL EXCEPTION: main\nProcess: com.example.app, PID: 1234\n"""
+        issues = self._find_issues(log)
+        self.assertIn(
+            "AndroidRuntime reported a fatal exception while instrumentation tests were running",
+            issues,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- require AndroidRuntime fatal exception matches the NovaPDF Reader process before flagging a crash
- add unit tests around the logcat crash detection helper

## Testing
- python -m unittest tools.test_check_logcat_for_crashes

------
https://chatgpt.com/codex/tasks/task_e_68e003583170832b8fe7f792a710b69f