### PR TITLE
Fix screenshot harness cache directory selection

### DIFF
--- a/app/src/androidTest/kotlin/com/novapdf/reader/ScreenshotHarnessTest.kt
+++ b/app/src/androidTest/kotlin/com/novapdf/reader/ScreenshotHarnessTest.kt
@@ -148,8 +148,6 @@ class ScreenshotHarnessTest {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
 
         val candidateDirectories = buildList {
-            addAll(cacheCandidatesForContext(instrumentation.context))
-
             runCatching { findTestPackageCacheDir(testPackageName) }
                 .onFailure { error ->
                     Log.w(
@@ -160,6 +158,8 @@ class ScreenshotHarnessTest {
                 }
                 .getOrNull()
                 ?.let(::add)
+
+            addAll(cacheCandidatesForContext(instrumentation.context))
         }
 
         val cacheDir = candidateDirectories


### PR DESCRIPTION
## Summary
- ensure the screenshot harness writes handshake flags inside the test package cache directory when available
- retain the instrumentation-context fallback when the test package directory cannot be prepared

## Testing
- ./gradlew :app:assembleDebug

------
https://chatgpt.com/codex/tasks/task_e_68e02595b45c832b836d0d45b65779a2