### PR TITLE
Initialise WorkManager before running UI automator tests

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -618,6 +618,7 @@ dependencies {
     androidTestImplementation("androidx.test.ext:junit:1.2.1")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")
     androidTestImplementation("androidx.test.uiautomator:uiautomator:2.3.0")
+    androidTestImplementation("androidx.work:work-testing:2.9.0")
     androidTestImplementation("androidx.compose.ui:ui-test-junit4")
     androidTestUtil("androidx.test:orchestrator:1.4.2")
     debugImplementation("androidx.compose.ui:ui-tooling")


### PR DESCRIPTION
## Summary
- initialise WorkManager in the PdfViewerUiAutomatorTest setup so instrumentation runs can obtain an instance without crashing
- depend on androidx.work:work-testing in androidTest sources to provide the WorkManager test initialisation helper

## Testing
- ./gradlew :app:compileDebugAndroidTestKotlin --console=plain
- ./gradlew :app:testDebugUnitTest --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68e094416f4c832b9c3ed4a88bf1f722