### PR TITLE
Initialize WorkManager before running screenshot harness

### DIFF
--- a/app/src/androidTest/kotlin/com/novapdf/reader/ScreenshotHarnessTest.kt
+++ b/app/src/androidTest/kotlin/com/novapdf/reader/ScreenshotHarnessTest.kt
@@ -12,7 +12,9 @@ import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
+import androidx.work.Configuration
 import androidx.work.WorkManager
+import androidx.work.testing.WorkManagerTestInitHelper
 import java.io.File
 import java.io.IOException
 import java.util.Locale
@@ -52,6 +54,7 @@ class ScreenshotHarnessTest {
         appContext = ApplicationProvider.getApplicationContext()
         handshakePackageName = resolveTestPackageName()
         handshakeCacheDir = resolveHandshakeCacheDir(handshakePackageName)
+        ensureWorkManagerInitialized(appContext)
         documentUri = TestDocumentFixtures.installThousandPageDocument(appContext)
         cancelWorkManagerJobs()
     }
@@ -261,6 +264,16 @@ class ScreenshotHarnessTest {
             } catch (error: Exception) {
                 Log.w(TAG, "Unexpected failure cancelling WorkManager jobs for screenshot harness", error)
             }
+        }
+    }
+
+    private fun ensureWorkManagerInitialized(context: Context) {
+        val appContext = context.applicationContext
+        runCatching { WorkManager.getInstance(appContext) }.onFailure {
+            val configuration = Configuration.Builder()
+                .setMinimumLoggingLevel(Log.DEBUG)
+                .build()
+            WorkManagerTestInitHelper.initializeTestWorkManager(appContext, configuration)
         }
     }
 

--- a/app/src/test/kotlin/com/novapdf/reader/ThousandPagePdfPdfiumTest.kt
+++ b/app/src/test/kotlin/com/novapdf/reader/ThousandPagePdfPdfiumTest.kt
@@ -1,0 +1,39 @@
+package com.novapdf.reader
+
+import androidx.core.net.toUri
+import androidx.test.core.app.ApplicationProvider
+import com.novapdf.reader.data.PdfDocumentRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = TestPdfApp::class)
+class ThousandPagePdfPdfiumTest {
+
+    @Test
+    fun `pdfium can open generated thousand page document`() = runBlocking {
+        val app = ApplicationProvider.getApplicationContext<TestPdfApp>()
+        val cacheFile = File(app.cacheDir, "pdfium-thousand-pages.pdf")
+        cacheFile.parentFile?.mkdirs()
+        cacheFile.outputStream().use { output ->
+            ThousandPagePdfWriter(1_000).writeTo(output)
+        }
+
+        val repository = PdfDocumentRepository(app)
+        try {
+            val session = withContext(Dispatchers.IO) {
+                repository.open(cacheFile.toUri())
+            }
+            assertEquals(1_000, session.pageCount)
+        } finally {
+            repository.dispose()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- initialize the test WorkManager before launching the screenshot harness so the instrumentation setup no longer crashes
- add a Robolectric regression test to confirm Pdfium can open the generated thousand-page stress document

## Testing
- `./gradlew test --console=plain --rerun-tasks`


------
https://chatgpt.com/codex/tasks/task_e_68e0c458a718832ba989d50e699f9a60