### PR TITLE
Fix screenshot harness rule visibility

### DIFF
--- a/app/src/androidTest/kotlin/com/novapdf/reader/ScreenshotHarnessTest.kt
+++ b/app/src/androidTest/kotlin/com/novapdf/reader/ScreenshotHarnessTest.kt
@@ -434,7 +434,7 @@ class ScreenshotHarnessTest {
         }
     }
 
-    private class HarnessTestWatcher(
+    class HarnessTestWatcher(
         private val onEvent: (String) -> Unit,
         private val onFailure: (String, Throwable) -> Unit,
     ) : TestWatcher() {


### PR DESCRIPTION
## Summary
- make the ScreenshotHarnessTest watcher class public so the rule exposes a visible type

## Testing
- `./gradlew :app:compileDebugAndroidTestKotlin --console=plain` *(fails: compilation error in generated Room sources unrelated to change)*

------
https://chatgpt.com/codex/tasks/task_e_68e1197d8c78832b8d76e3bfc6432ca6