### PR TITLE
Add missing __init__ to tools package for logcat tests

### DIFF
--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,4 @@
+"""Utilities for NovaPDFReader tooling scripts."""
+
+# This file enables the ``tools`` directory to be imported as a package so
+# that our unit tests can import ``tools.check_logcat_for_crashes``.


### PR DESCRIPTION
## Summary
- add an __init__ module so the tools package can be imported in unit tests

## Testing
- pytest tools/test_check_logcat_for_crashes.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e12e2c3ac8832ba88d93c6c23e275a