### PR TITLE
Handle inaccessible cache dirs in screenshot harness

### DIFF
--- a/app/src/androidTest/kotlin/com/novapdf/reader/ScreenshotHarnessTest.kt
+++ b/app/src/androidTest/kotlin/com/novapdf/reader/ScreenshotHarnessTest.kt
@@ -276,7 +276,23 @@ class ScreenshotHarnessTest {
         if (directory == null) {
             return false
         }
-        return directory.exists() || directory.mkdirs()
+
+        return try {
+            if (directory.exists() || directory.mkdirs()) {
+                true
+            } else {
+                logHarnessWarn(
+                    "Unable to prepare screenshot handshake cache directory at ${directory.absolutePath}"
+                )
+                false
+            }
+        } catch (error: SecurityException) {
+            logHarnessWarn(
+                "Skipping screenshot handshake cache directory at ${directory.absolutePath}; access denied",
+                error
+            )
+            false
+        }
     }
 
     private fun findTestPackageCacheDir(testPackageName: String): File {


### PR DESCRIPTION
## Summary
- guard the screenshot harness cache directory setup against SecurityException
- log and skip cache locations that cannot be prepared instead of letting the harness crash

## Testing
- not run (instrumented tests require an Android device)


------
https://chatgpt.com/codex/tasks/task_e_68e151a71bb4832b8af53e3c2bf344cc