### PR TITLE
Keep ML Kit and Lucene classes during release shrinking

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -5,3 +5,14 @@
 # pdfbox-android references an optional JPEG2000 decoder which isn't bundled.
 # Suppress R8 missing class errors so release builds can succeed without it.
 -dontwarn com.gemalto.jp2.**
+
+# Lucene, PdfBox, and ML Kit rely on extensive reflection. R8 was stripping
+# their implementation classes from release builds which triggered runtime
+# crashes when the screenshot harness tried to open documents. Keep their
+# public APIs intact so the viewer can initialise search and OCR components
+# safely when minification is enabled.
+-keep class org.apache.lucene.** { *; }
+-keep class com.tom_roush.** { *; }
+-keep class com.google.mlkit.** { *; }
+-keep class com.google.android.gms.internal.mlkit_vision_text_common.** { *; }
+-keep class com.google.android.gms.internal.mlkit_vision_common.** { *; }


### PR DESCRIPTION
## Summary
- add ProGuard keep rules so Lucene, PdfBox, and ML Kit code survives R8 minification
- prevent release builds from stripping OCR/search dependencies required by the screenshot harness

## Testing
- `./gradlew test --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_68e1704fc3ec832bb8430f0afa5eae30