### PR TITLE
Handle PDFBox init failures during screenshot harness

### DIFF
--- a/app/src/main/kotlin/com/novapdf/reader/search/LuceneSearchCoordinator.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/search/LuceneSearchCoordinator.kt
@@ -243,7 +243,11 @@ class LuceneSearchCoordinator(
     private suspend fun extractPageContent(session: PdfDocumentSession): List<PageSearchContent> = withContext(Dispatchers.IO) {
         val pageCount = session.pageCount
         if (pageCount <= 0) return@withContext emptyList()
-        PdfBoxInitializer.ensureInitialized(context)
+        val pdfBoxReady = PdfBoxInitializer.ensureInitialized(context)
+        if (!pdfBoxReady) {
+            Log.w(TAG, "PDFBox initialisation failed; skipping text extraction")
+            return@withContext emptyList()
+        }
         val contents = MutableList(pageCount) {
             PageSearchContent(
                 text = "",

--- a/app/src/main/kotlin/com/novapdf/reader/search/PdfBoxInitializer.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/search/PdfBoxInitializer.kt
@@ -1,6 +1,7 @@
 package com.novapdf.reader.search
 
 import android.content.Context
+import android.util.Log
 import com.tom_roush.pdfbox.android.PDFBoxResourceLoader
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlinx.coroutines.Dispatchers
@@ -12,15 +13,27 @@ internal object PdfBoxInitializer {
     private val initialized = AtomicBoolean(false)
     private val mutex = Mutex()
 
-    suspend fun ensureInitialized(context: Context) {
-        if (initialized.get()) return
-        mutex.withLock {
-            if (!initialized.get()) {
+    suspend fun ensureInitialized(context: Context): Boolean {
+        if (initialized.get()) return true
+        return mutex.withLock {
+            if (initialized.get()) {
+                return@withLock true
+            }
+            val success = try {
                 withContext(Dispatchers.IO) {
                     PDFBoxResourceLoader.init(context.applicationContext)
                 }
+                true
+            } catch (error: Throwable) {
+                Log.w(TAG, "Unable to initialise PDFBox resources", error)
+                false
+            }
+            if (success) {
                 initialized.set(true)
             }
+            success
         }
     }
+
+    private const val TAG = "PdfBoxInitializer"
 }


### PR DESCRIPTION
## Summary
- guard background application initialisation so PDFBox setup failures are logged instead of crashing the process
- make PdfBoxInitializer report its status and log failures for later diagnostics
- skip Lucene search extraction when PDFBox resources are unavailable to keep the viewer responsive

## Testing
- `./gradlew testDebugUnitTest --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_68e1fd0c21b8832bbee850ed83f3275a