### PR TITLE
Prefer writer-generated thousand page fixture for screenshot harness

### DIFF
--- a/docs/regressions/2024-09-pdfium-crash.md
+++ b/docs/regressions/2024-09-pdfium-crash.md
@@ -18,6 +18,7 @@
 
 * Upgraded Pdfium to `com.github.mhiew:pdfium-android:1.9.2`, which ships the upstream crash fix for extremely large documents on Android 13+.
 * Regenerated the bundled thousand-page PDF fixture with a balanced `/Pages` tree so the harness no longer drives the legacy ReportLab asset that exposed huge `/Kids` arrays.
+* Preferred the deterministic on-device writer for the harness fixture generation so outdated bundled assets cannot reintroduce the regression.
 * Keep the screenshot harness in the connected test suite so regressions surface quickly in CI.
 * When diagnosing related issues, capture a logcat trace while running the harness to confirm whether Pdfium threw a managed exception (handled by `PdfDocumentRepository`) or a native abort.
 


### PR DESCRIPTION
## Summary
- use the deterministic writer to build the thousand-page harness fixture before consulting the bundled asset or network
- note the writer preference in the pdfium crash regression record to avoid stale assets causing regressions

## Testing
- ./gradlew testDebugUnitTest --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68e22fa8daac832baed5cc6a390f397c