### PR TITLE
Handle secure storage failures in annotation repository

### DIFF
--- a/app/src/main/kotlin/com/novapdf/reader/data/AnnotationRepository.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/data/AnnotationRepository.kt
@@ -1,7 +1,9 @@
 package com.novapdf.reader.data
 
 import android.content.Context
+import android.content.SharedPreferences
 import android.util.Base64
+import android.util.Log
 import androidx.core.content.edit
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
@@ -12,21 +14,21 @@ import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import java.io.File
 
-class AnnotationRepository(private val context: Context) {
+class AnnotationRepository(
+    context: Context,
+    private val securePreferencesProvider: (Context) -> SharedPreferences = Companion::createEncryptedPreferences,
+    private val fallbackPreferencesProvider: (Context) -> SharedPreferences = Companion::createUnencryptedPreferences,
+) {
+    private val appContext = context.applicationContext
     private val json = Json { prettyPrint = true }
     private val inMemoryAnnotations = mutableMapOf<String, MutableList<AnnotationCommand>>()
     private val lock = Any()
-    private val encryptedPreferences by lazy {
-        val masterKey = MasterKey.Builder(context)
-            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
-            .build()
-        EncryptedSharedPreferences.create(
-            context,
-            PREFERENCES_FILE_NAME,
-            masterKey,
-            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
-        )
+    private val preferences: SharedPreferences by lazy {
+        runCatching { securePreferencesProvider(appContext) }
+            .onFailure { error ->
+                Log.w(TAG, "Falling back to unencrypted annotation preferences", error)
+            }
+            .getOrElse { fallbackPreferencesProvider(appContext) }
     }
 
     fun annotationsForDocument(documentId: String): List<AnnotationCommand> =
@@ -57,16 +59,35 @@ class AnnotationRepository(private val context: Context) {
         } ?: return@withContext null
         val encodedId = Base64.encodeToString(documentId.toByteArray(), Base64.URL_SAFE or Base64.NO_WRAP)
         val payload = json.encodeToString(annotations)
-        encryptedPreferences.edit(commit = true) {
+        preferences.edit(commit = true) {
             putString(encodedId, payload)
         }
-        preferenceFile(context)
+        preferenceFile(appContext)
     }
 
     fun trackedDocumentIds(): Set<String> = synchronized(lock) { inMemoryAnnotations.keys.toSet() }
 
     companion object {
         const val PREFERENCES_FILE_NAME = "annotation_repository"
+        private const val TAG = "AnnotationRepository"
+
+        private fun createEncryptedPreferences(context: Context): SharedPreferences {
+            val appContext = context.applicationContext
+            val masterKey = MasterKey.Builder(appContext)
+                .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+                .build()
+            return EncryptedSharedPreferences.create(
+                appContext,
+                PREFERENCES_FILE_NAME,
+                masterKey,
+                EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+                EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+            )
+        }
+
+        private fun createUnencryptedPreferences(context: Context): SharedPreferences {
+            return context.applicationContext.getSharedPreferences(PREFERENCES_FILE_NAME, Context.MODE_PRIVATE)
+        }
 
         fun preferenceFile(context: Context): File {
             val appContext = context.applicationContext

--- a/app/src/test/kotlin/com/novapdf/reader/data/AnnotationRepositoryTest.kt
+++ b/app/src/test/kotlin/com/novapdf/reader/data/AnnotationRepositoryTest.kt
@@ -1,14 +1,17 @@
 package com.novapdf.reader.data
 
 import android.app.Application
+import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import com.novapdf.reader.model.AnnotationCommand
 import com.novapdf.reader.model.PointSnapshot
+import com.novapdf.reader.model.RectSnapshot
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -23,6 +26,7 @@ class AnnotationRepositoryTest {
 
     @Test
     fun addAndPersistAnnotations() = runTest {
+        AnnotationRepository.preferenceFile(context).delete()
         val repository = AnnotationRepository(context)
         val documentId = "test-doc"
         val stroke = AnnotationCommand.Stroke(
@@ -40,9 +44,39 @@ class AnnotationRepositoryTest {
         val file = repository.saveAnnotations(documentId)
         assertNotNull(file)
         val prefsFile = file!!
-        assertEquals(true, prefsFile.exists())
+        assertTrue(prefsFile.exists())
         val fileContents = prefsFile.readText()
         assertFalse(fileContents.contains(documentId))
         assertFalse(fileContents.contains("{"))
+    }
+
+    @Test
+    fun fallsBackToUnencryptedPreferencesWhenSecureStorageUnavailable() = runTest {
+        AnnotationRepository.preferenceFile(context).delete()
+        var fallbackInvoked = false
+        val repository = AnnotationRepository(
+            context,
+            securePreferencesProvider = { throw IllegalStateException("secure storage unavailable") },
+            fallbackPreferencesProvider = { appContext ->
+                fallbackInvoked = true
+                appContext.getSharedPreferences(AnnotationRepository.PREFERENCES_FILE_NAME, Context.MODE_PRIVATE)
+            }
+        )
+
+        val annotation = AnnotationCommand.Highlight(
+            pageIndex = 0,
+            rect = RectSnapshot(0f, 0f, 10f, 10f),
+            color = 0xff0000
+        )
+        repository.addAnnotation("doc", annotation)
+
+        val savedFile = repository.saveAnnotations("doc")
+
+        assertTrue("fallback preferences should be used", fallbackInvoked)
+        assertNotNull("annotations should be persisted when fallback is active", savedFile)
+        assertTrue(
+            "fallback preferences file should exist",
+            AnnotationRepository.preferenceFile(context).exists()
+        )
     }
 }


### PR DESCRIPTION
## Summary
- add a fallback path in `AnnotationRepository` when encrypted shared preferences cannot be created
- cover the new fallback with a Robolectric unit test while keeping the existing persistence test

## Testing
- ./gradlew testDebugUnitTest

------
https://chatgpt.com/codex/tasks/task_e_68e23903ef94832bbf1d94d304ff978e