### PR TITLE
Fix androidTest validation helper signature

### DIFF
--- a/app/src/androidTest/kotlin/com/novapdf/reader/TestDocumentFixtures.kt
+++ b/app/src/androidTest/kotlin/com/novapdf/reader/TestDocumentFixtures.kt
@@ -300,7 +300,7 @@ internal object TestDocumentFixtures {
             return false
         }
 
-        if (!validatePageTree(contents)) {
+        if (!validatePageTree(candidate, contents)) {
             Log.w(
                 TAG,
                 "Validation failed for thousand-page PDF due to oversized /Kids arrays"
@@ -316,7 +316,7 @@ internal object TestDocumentFixtures {
         return true
     }
 
-    private fun validatePageTree(contents: String): Boolean {
+    private fun validatePageTree(candidate: File, contents: String): Boolean {
         val kidsMatcher = KIDS_ARRAY_PATTERN.matcher(contents)
         while (kidsMatcher.find()) {
             val kidsSection = kidsMatcher.group(1)


### PR DESCRIPTION
## Summary
- pass the thousand-page PDF candidate file to the page tree validator to retain logging context
- update the page tree validator signature to accept the candidate file reference

## Testing
- `./gradlew :app:compileDebugAndroidTestKotlin --console=plain`

------
https://chatgpt.com/codex/tasks/task_e_68e287916ac8832b915e0ba7321620db