### PR TITLE
Ensure crash logs are written where screenshot harness can collect them

### DIFF
--- a/app/src/main/kotlin/com/novapdf/reader/logging/FileCrashReporter.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/logging/FileCrashReporter.kt
@@ -3,6 +3,7 @@ package com.novapdf.reader.logging
 import android.content.Context
 import android.os.Build
 import android.util.Log
+import androidx.annotation.VisibleForTesting
 import java.io.File
 import java.io.FileWriter
 import java.io.IOException
@@ -95,6 +96,9 @@ class FileCrashReporter(
         }
     }
 
+    @VisibleForTesting
+    internal fun crashLogDirectory(): File? = logDirectory
+
     private fun writeLog(file: File, entry: String) {
         FileWriter(file, false).use { writer ->
             writer.write(entry)
@@ -149,13 +153,13 @@ class FileCrashReporter(
 
         private fun safeDirectoriesForContext(context: Context): List<File> {
             return buildList {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                    addIfPresent { context.dataDir }
+                }
                 addIfPresent { context.filesDir }
                 addIfPresent { context.cacheDir }
                 addIfPresent { context.codeCacheDir }
                 addIfPresent { context.noBackupFilesDir }
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-                    addIfPresent { context.dataDir }
-                }
             }
         }
 

--- a/app/src/test/kotlin/com/novapdf/reader/logging/FileCrashReporterTest.kt
+++ b/app/src/test/kotlin/com/novapdf/reader/logging/FileCrashReporterTest.kt
@@ -1,0 +1,28 @@
+package com.novapdf.reader.logging
+
+import androidx.test.core.app.ApplicationProvider
+import com.novapdf.reader.TestPdfApp
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = TestPdfApp::class)
+class FileCrashReporterTest {
+
+    @Test
+    fun `crash logs directory defaults to application data root`() {
+        val app = ApplicationProvider.getApplicationContext<TestPdfApp>()
+        val reporter = FileCrashReporter(app)
+
+        val directory = reporter.crashLogDirectory()
+        assertNotNull("Crash log directory should be initialised", directory)
+        val resolved = directory!!.canonicalFile
+        val expectedParent = app.dataDir?.canonicalFile
+        assertEquals(expectedParent, resolved.parentFile?.canonicalFile)
+        assertEquals("crashlogs", resolved.name)
+    }
+}


### PR DESCRIPTION
## Summary
- prefer the application data directory when resolving the crash log location and expose the resolved path for tests
- add a Robolectric regression test verifying the crash reporter stores logs under `<app data>/crashlogs`

## Testing
- ./gradlew testDebugUnitTest


------
https://chatgpt.com/codex/tasks/task_e_68e29d0897bc832b9daf3dc4d8a7f6c8