### PR TITLE
Delay screenshot harness opens until ReaderActivity is started

### DIFF
--- a/app/src/main/kotlin/com/novapdf/reader/ReaderActivity.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/ReaderActivity.kt
@@ -25,6 +25,7 @@ import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.whenStarted
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.novapdf.reader.R
@@ -280,7 +281,16 @@ open class ReaderActivity : ComponentActivity() {
 
     @VisibleForTesting
     internal fun openDocumentForTest(uri: Uri) {
-        viewModel.openDocument(uri)
+        if (!useComposeUi) {
+            viewModel.openDocument(uri)
+            return
+        }
+
+        lifecycleScope.launch {
+            lifecycle.whenStarted {
+                viewModel.openDocument(uri)
+            }
+        }
     }
 
     @VisibleForTesting


### PR DESCRIPTION
## Summary
- delay calls from test harnesses so ReaderActivity waits for its lifecycle to reach STARTED before opening documents when the Compose UI is active
- add the lifecycle runtime helper import required for the deferred launch

## Testing
- ./gradlew test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68e30f1b3404832b88b3398f3032dad6