### PR TITLE
Refactor EchoModeController TTS initialization

### DIFF
--- a/app/src/main/kotlin/com/novapdf/reader/EchoModeController.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/EchoModeController.kt
@@ -6,6 +6,12 @@ import android.util.Log
 import java.util.ArrayDeque
 import java.util.Locale
 import java.util.UUID
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
 
 /**
  * Handles TextToSpeech playback for Echo Mode summaries and coordinates fallbacks when
@@ -13,50 +19,41 @@ import java.util.UUID
  */
 class EchoModeController(context: Context) : TextToSpeech.OnInitListener {
     private val applicationContext = context.applicationContext
-    private val textToSpeech: TextToSpeech?
+    @Volatile private var textToSpeech: TextToSpeech? = null
     private val pendingRequests = ArrayDeque<EchoRequest>()
+    private val supervisor = SupervisorJob()
+    private val initScope = CoroutineScope(supervisor + Dispatchers.IO)
+    private val mainScope = CoroutineScope(supervisor + Dispatchers.Main.immediate)
 
     private var isInitialized = false
     private var readyForPlayback = false
-
-    init {
-        val initialised = runCatching { TextToSpeech(applicationContext, this) }
-        textToSpeech = initialised.getOrNull()
-        if (textToSpeech == null) {
-            // Some devices (particularly headless CI images) do not ship with a TTS engine. The
-            // platform constructor throws synchronously in that scenario, so mark the controller
-            // as initialised but unavailable so that callers can gracefully fall back to haptics
-            // instead of crashing the process during composition.
-            isInitialized = true
-            readyForPlayback = false
-            Log.w(TAG, "TextToSpeech engine unavailable; falling back to haptic feedback", initialised.exceptionOrNull())
-            drainPendingWithFallback()
-        }
-    }
+    private var initializationJob: Job? = null
 
     override fun onInit(status: Int) {
-        val engine = textToSpeech
-        if (engine == null) {
+        mainScope.launch {
+            val engine = textToSpeech
+            if (engine == null) {
+                isInitialized = true
+                readyForPlayback = false
+                drainPendingWithFallback()
+                return@launch
+            }
             isInitialized = true
-            readyForPlayback = false
-            drainPendingWithFallback()
-            return
-        }
-        isInitialized = true
-        readyForPlayback = status == TextToSpeech.SUCCESS
-        if (!readyForPlayback) {
-            drainPendingWithFallback()
-            return
-        }
+            readyForPlayback = status == TextToSpeech.SUCCESS
+            if (!readyForPlayback) {
+                drainPendingWithFallback()
+                return@launch
+            }
 
-        val localeResult = engine.setLanguage(Locale.getDefault())
-        if (localeResult == TextToSpeech.LANG_MISSING_DATA || localeResult == TextToSpeech.LANG_NOT_SUPPORTED) {
-            readyForPlayback = false
-            drainPendingWithFallback()
-            return
-        }
+            val localeResult = engine.setLanguage(Locale.getDefault())
+            if (localeResult == TextToSpeech.LANG_MISSING_DATA || localeResult == TextToSpeech.LANG_NOT_SUPPORTED) {
+                readyForPlayback = false
+                drainPendingWithFallback()
+                return@launch
+            }
 
-        flushPending()
+            flushPending()
+        }
     }
 
     /**
@@ -69,30 +66,32 @@ class EchoModeController(context: Context) : TextToSpeech.OnInitListener {
             return
         }
 
-        if (!readyForPlayback) {
-            if (isInitialized) {
-                onFallback()
-            } else {
+        val engine = textToSpeech
+        when {
+            readyForPlayback && engine != null -> {
+                val result = engine.speak(
+                    trimmedSummary,
+                    TextToSpeech.QUEUE_FLUSH,
+                    /* params = */ null,
+                    /* utteranceId = */ UUID.randomUUID().toString()
+                )
+                if (result != TextToSpeech.SUCCESS) {
+                    onFallback()
+                }
+            }
+            !isInitialized -> {
                 pendingRequests.clear()
                 pendingRequests.addLast(EchoRequest(trimmedSummary, onFallback))
+                ensureInitialised()
             }
-            return
-        }
-
-        val engine = textToSpeech
-        if (engine == null) {
-            onFallback()
-            return
-        }
-
-        val result = engine.speak(
-            trimmedSummary,
-            TextToSpeech.QUEUE_FLUSH,
-            /* params = */ null,
-            /* utteranceId = */ UUID.randomUUID().toString()
-        )
-        if (result != TextToSpeech.SUCCESS) {
-            onFallback()
+            !readyForPlayback -> {
+                onFallback()
+            }
+            else -> {
+                pendingRequests.clear()
+                pendingRequests.addLast(EchoRequest(trimmedSummary, onFallback))
+                ensureInitialised()
+            }
         }
     }
 
@@ -105,6 +104,8 @@ class EchoModeController(context: Context) : TextToSpeech.OnInitListener {
             engine.stop()
             engine.shutdown()
         }
+        textToSpeech = null
+        supervisor.cancel()
     }
 
     private fun flushPending() {
@@ -130,6 +131,26 @@ class EchoModeController(context: Context) : TextToSpeech.OnInitListener {
     private fun drainPendingWithFallback() {
         while (pendingRequests.isNotEmpty()) {
             pendingRequests.removeFirst().onFallback()
+        }
+    }
+
+    private fun ensureInitialised() {
+        if (isInitialized || initializationJob?.isActive == true) {
+            return
+        }
+        initializationJob = initScope.launch {
+            val initialised = runCatching { TextToSpeech(applicationContext, this@EchoModeController) }
+            val engine = initialised.getOrNull()
+            textToSpeech = engine
+            initializationJob = null
+            if (engine == null) {
+                Log.w(TAG, "TextToSpeech engine unavailable; falling back to haptic feedback", initialised.exceptionOrNull())
+                mainScope.launch {
+                    isInitialized = true
+                    readyForPlayback = false
+                    drainPendingWithFallback()
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- lazily initialize TextToSpeech on a background dispatcher to avoid blocking composition
- queue echo requests until initialization completes and flush or fallback appropriately
- ensure controller cancels coroutine scopes on shutdown to prevent leaks

## Testing
- ./gradlew :app:testDebugUnitTest --tests com.novapdf.reader.ThousandPagePdfWriterTest --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68e3282cc340832b84dcc8f0c67cb583