### PR TITLE
Handle ambiguous PDF MIME types for harness fixtures

### DIFF
--- a/app/src/test/kotlin/com/novapdf/reader/data/PdfDocumentRepositoryMimeTypeTest.kt
+++ b/app/src/test/kotlin/com/novapdf/reader/data/PdfDocumentRepositoryMimeTypeTest.kt
@@ -1,0 +1,38 @@
+package com.novapdf.reader.data
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class PdfDocumentRepositoryMimeTypeTest {
+
+    @Test
+    fun `reported pdf mime type is preserved`() {
+        val result = normalizedMimeType("application/pdf", null)
+        assertEquals("application/pdf", result)
+    }
+
+    @Test
+    fun `ambiguous mime type falls back to pdf extension`() {
+        val result = normalizedMimeType("application/octet-stream", "pdf")
+        assertEquals("application/pdf", result)
+    }
+
+    @Test
+    fun `ambiguous mime type without extension remains unknown`() {
+        val result = normalizedMimeType("application/octet-stream", null)
+        assertNull(result)
+    }
+
+    @Test
+    fun `vendor specific pdf mime type normalizes to standard`() {
+        val result = normalizedMimeType("application/x-pdf", null)
+        assertEquals("application/pdf", result)
+    }
+
+    @Test
+    fun `missing mime type uses pdf extension`() {
+        val result = normalizedMimeType(null, "pdf")
+        assertEquals("application/pdf", result)
+    }
+}


### PR DESCRIPTION
## Summary
- normalize MIME type detection for file-backed documents so generic types fall back to PDF extensions
- expose the normalization helper for testing and add coverage for common ambiguous MIME type cases

## Testing
- ./gradlew :app:testDebugUnitTest --tests com.novapdf.reader.data.PdfDocumentRepositoryMimeTypeTest

------
https://chatgpt.com/codex/tasks/task_e_68e336931ae8832b84e6c48ef7ea54e5