### PR TITLE
Ensure PDF repair fallback initializes PdfBox

### DIFF
--- a/docs/regressions/2024-09-pdfium-crash.md
+++ b/docs/regressions/2024-09-pdfium-crash.md
@@ -19,6 +19,7 @@
 * Upgraded Pdfium to `com.github.mhiew:pdfium-android:1.9.2`, which ships the upstream crash fix for extremely large documents on Android 13+.
 * Regenerated the bundled thousand-page PDF fixture with a balanced `/Pages` tree so the harness no longer drives the legacy ReportLab asset that exposed huge `/Kids` arrays.
 * Preferred the deterministic on-device writer for the harness fixture generation so outdated bundled assets cannot reintroduce the regression.
+* Added a PdfBox-powered repair fallback in `PdfDocumentRepository` that rewrites problematic PDFs into a balanced form before handing them to Pdfium, ensuring native crashes are avoided even when large `/Pages` trees are encountered in the field.
 * Keep the screenshot harness in the connected test suite so regressions surface quickly in CI.
 * When diagnosing related issues, capture a logcat trace while running the harness to confirm whether Pdfium threw a managed exception (handled by `PdfDocumentRepository`) or a native abort.
 


### PR DESCRIPTION
## Summary
- ensure the PDF repair cache directory is created and warn if unavailable
- initialise PdfBox before repairing documents and clean up failed repair attempts
- document the repair fallback in the regression notes

## Testing
- ./gradlew :app:testDebugUnitTest


------
https://chatgpt.com/codex/tasks/task_e_68e351cc9150832b81bbf450cf87356d