### PR TITLE
Disable heavy prefetching for huge PDFs

### DIFF
--- a/app/src/main/kotlin/com/novapdf/reader/PdfViewerScreen.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/PdfViewerScreen.kt
@@ -1968,16 +1968,18 @@ private fun PdfPager(
             reverse = true
         )
 
-        ThumbnailStrip(
-            state = state,
-            lazyListState = lazyListState,
-            renderPage = latestRenderPage,
-            onToggleBookmark = latestBookmarkToggle,
-            modifier = Modifier
-                .align(Alignment.BottomCenter)
-                .fillMaxWidth()
-                .padding(bottom = 24.dp)
-        )
+        if (state.pageCount in 1..LARGE_DOCUMENT_PAGE_THRESHOLD) {
+            ThumbnailStrip(
+                state = state,
+                lazyListState = lazyListState,
+                renderPage = latestRenderPage,
+                onToggleBookmark = latestBookmarkToggle,
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .fillMaxWidth()
+                    .padding(bottom = 24.dp)
+            )
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- stop background page prefetching once a document exceeds 400 pages to avoid overwhelming memory
- hide the thumbnail strip for large documents so the UI skips extra bitmap work
- add a unit test to confirm that large documents do not trigger repository prefetching

## Testing
- ./gradlew testDebugUnitTest --console=plain -x compileNonMinifiedReleaseJavaWithJavac -x compileNonMinifiedReleaseKotlin -x kaptNonMinifiedReleaseKotlin -x compileNonMinifiedReleaseUnitTestKotlin

------
https://chatgpt.com/codex/tasks/task_e_68e36cc99954832b859b2addf0838f72