### PR TITLE
Limit screenshot harness idle wait before signaling readiness

### DIFF
--- a/app/src/androidTest/kotlin/com/novapdf/reader/ScreenshotHarnessTest.kt
+++ b/app/src/androidTest/kotlin/com/novapdf/reader/ScreenshotHarnessTest.kt
@@ -450,7 +450,7 @@ class ScreenshotHarnessTest {
                 logHarnessInfo(
                     "Thousand-page document finished loading with pageCount=${snapshot?.pageCount}"
                 )
-                device.waitForIdle()
+                device.waitForIdle(DEVICE_IDLE_TIMEOUT_MS)
                 return
             }
 
@@ -611,6 +611,7 @@ class ScreenshotHarnessTest {
         // viewer ample time to finish rendering before failing the harness run.
         private const val DOCUMENT_OPEN_TIMEOUT = 180_000L
         private const val WORK_MANAGER_CANCEL_TIMEOUT_SECONDS = 15L
+        private const val DEVICE_IDLE_TIMEOUT_MS = 10_000L
         private const val TAG = "ScreenshotHarness"
     }
 


### PR DESCRIPTION
## Summary
- add a bounded UiAutomator idle wait in the screenshot harness so readiness is signaled even under persistent UI activity

## Testing
- ./gradlew :app:compileDebugAndroidTestKotlin

------
https://chatgpt.com/codex/tasks/task_e_68e39161a7b4832ba54ce1c91dd6b2af