### PR TITLE
Prioritize bundled thousand-page fixture for screenshot harness

### DIFF
--- a/app/src/androidTest/kotlin/com/novapdf/reader/TestDocumentFixtures.kt
+++ b/app/src/androidTest/kotlin/com/novapdf/reader/TestDocumentFixtures.kt
@@ -278,20 +278,22 @@ internal object TestDocumentFixtures {
             throw IOException("Unable to clear stale thousand-page PDF cache")
         }
 
-        val preparedFromWriter = tryGenerateThousandPagePdf(tempFile)
+        val preparedFromAsset = copyBundledThousandPagePdf(tempFile)
+        val preparedFromNetwork = if (!preparedFromAsset) {
+            tryDownloadThousandPagePdf(tempFile)
+        } else {
+            false
+        }
+        val preparedFromWriter = if (!preparedFromAsset && !preparedFromNetwork) {
+            tryGenerateThousandPagePdf(tempFile)
+        } else {
+            false
+        }
 
-        if (!preparedFromWriter) {
+        if (!preparedFromAsset && !preparedFromNetwork && !preparedFromWriter) {
             try {
-                val preparedFromAsset = copyBundledThousandPagePdf(tempFile)
-                val preparedFromNetwork = if (!preparedFromAsset) {
-                    tryDownloadThousandPagePdf(tempFile)
-                } else {
-                    false
-                }
-                if (!preparedFromAsset && !preparedFromNetwork) {
-                    Log.i(TAG, "Falling back to thousand-page writer after asset/network failures")
-                    writeThousandPagePdf(tempFile)
-                }
+                Log.i(TAG, "Falling back to thousand-page writer after asset/network failures")
+                writeThousandPagePdf(tempFile)
             } catch (error: IOException) {
                 tempFile.delete()
                 throw error


### PR DESCRIPTION
## Summary
- load the thousand-page screenshot fixture from the bundled base64 asset before resorting to downloads or regeneration
- retain the writer fallback only after asset and network sources fail to keep the cache generation reliable

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68e39b1c2c30832b8239d5e14bb00ccc