### PR TITLE
Avoid recycling PDF page bitmaps during compose disposal

### DIFF
--- a/app/src/main/kotlin/com/novapdf/reader/PdfViewerScreen.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/PdfViewerScreen.kt
@@ -2231,11 +2231,11 @@ private fun PdfPageItem(
 
     DisposableEffect(pageIndex) {
         onDispose {
-            pageBitmap?.let { bitmap ->
-                if (!bitmap.isRecycled) {
-                    bitmap.recycle()
-                }
-            }
+            // Avoid explicitly recycling the bitmap here. When the composable leaves the
+            // composition Compose can still issue a final draw pass, and calling
+            // Bitmap.recycle() results in "Canvas: trying to use a recycled bitmap"
+            // crashes on large documents. Clearing the reference lets the bitmap be
+            // collected naturally without tripping the renderer.
             pageBitmap = null
         }
     }


### PR DESCRIPTION
## Summary
- stop recycling rendered page bitmaps when `PdfPageItem` leaves composition
- document why the bitmap reference is cleared without recycling to avoid Canvas crashes

## Testing
- ./gradlew test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68e3c22203f4832ba16ccc9737b58964