### PR TITLE
Prevent thumbnail recycling crashes in Compose viewer

### DIFF
--- a/app/src/main/kotlin/com/novapdf/reader/PdfViewerScreen.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/PdfViewerScreen.kt
@@ -2113,11 +2113,10 @@ private fun ThumbnailItem(
 
     DisposableEffect(documentId, pageIndex) {
         onDispose {
-            thumbnail?.let { bitmap ->
-                if (!bitmap.isRecycled) {
-                    bitmap.recycle()
-                }
-            }
+            // Avoid recycling thumbnails directly. Compose can issue a final draw after the
+            // composable leaves the composition, and calling Bitmap.recycle() here would crash
+            // with "Canvas: trying to use a recycled bitmap" on large documents. Clearing the
+            // reference allows the bitmap to be GC'd once it is no longer in use.
             thumbnail = null
         }
     }


### PR DESCRIPTION
## Summary
- stop recycling thumbnail bitmaps when their composable leaves composition to avoid Canvas crashes during screenshot harness runs
- document why thumbnails rely on garbage collection instead of explicit recycle calls

## Testing
- ./gradlew :app:testDebugUnitTest --tests com.novapdf.reader.ThousandPagePdfWriterTest

------
https://chatgpt.com/codex/tasks/task_e_68e3d109ecec832bb9ee47ff26c10c29