### PR TITLE
Centralize Android SDK version configuration

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,6 +19,7 @@ import java.time.Instant
 import java.time.format.DateTimeFormatter
 import java.util.Properties
 import java.util.concurrent.TimeUnit
+import org.gradle.api.artifacts.VersionCatalogsExtension
 
 fun Project.resolveSigningCredential(name: String, default: String? = null): String =
     (findProperty(name) as? String)?.takeIf { it.isNotBlank() }
@@ -72,15 +73,17 @@ val thousandPageFixtureUrlProvider = providers
     .orElse(providers.gradleProperty("thousandPageFixtureUrl"))
     .orElse("")
 
+val libs = extensions.getByType(VersionCatalogsExtension::class.java).named("libs")
+
 android {
     namespace = "com.novapdf.reader"
     testNamespace = "$resolvedApplicationId.test"
-    compileSdk = 35
+    compileSdk = libs.findVersion("androidCompileSdk").get().requiredVersion.toInt()
 
     defaultConfig {
         applicationId = resolvedApplicationId
-        minSdk = 26
-        targetSdk = 35
+        minSdk = libs.findVersion("androidMinSdk").get().requiredVersion.toInt()
+        targetSdk = libs.findVersion("androidTargetSdk").get().requiredVersion.toInt()
         versionCode = 1
         versionName = "1.0.0"
 

--- a/baselineprofile/build.gradle.kts
+++ b/baselineprofile/build.gradle.kts
@@ -2,6 +2,7 @@ import com.android.build.api.dsl.TestExtension
 import com.android.build.api.variant.TestAndroidComponentsExtension
 import org.gradle.api.GradleException
 import org.gradle.api.JavaVersion
+import org.gradle.api.artifacts.VersionCatalogsExtension
 import java.io.File
 import java.util.Properties
 import java.util.concurrent.TimeUnit
@@ -39,6 +40,8 @@ if (!rootLocalProperties.exists() && configuredAndroidSdk == null) {
     }
 }
 
+val libs = extensions.getByType(VersionCatalogsExtension::class.java).named("libs")
+
 plugins {
     id("com.android.test")
     id("org.jetbrains.kotlin.android")
@@ -47,11 +50,11 @@ plugins {
 
 android {
     namespace = "com.novapdf.reader.baselineprofile"
-    compileSdk = 35
+    compileSdk = libs.findVersion("androidCompileSdk").get().requiredVersion.toInt()
 
     defaultConfig {
-        minSdk = 26
-        targetSdk = 35
+        minSdk = libs.findVersion("androidMinSdk").get().requiredVersion.toInt()
+        targetSdk = libs.findVersion("androidTargetSdk").get().requiredVersion.toInt()
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,6 +11,9 @@ android.nonTransitiveRClass=true
 android.experimental.art-profile-r8-rewriting=true
 org.gradle.jvm.toolchain.installations.auto-download=true
 org.gradle.jvm.toolchain.installations.auto-detect=true
+android.compileSdk=35
+android.minSdk=26
+android.targetSdk=35
 android.suppressUnsupportedCompileSdk=35
 # Allow AGP to fetch missing command line SDK dependencies when no local installation is present.
 android.experimental.sdkDownload=true

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,6 +15,17 @@ dependencyResolutionManagement {
         google()
         mavenCentral()
     }
+    versionCatalogs {
+        create("libs") {
+            val compileSdk = providers.gradleProperty("android.compileSdk").map(String::trim).get()
+            val minSdk = providers.gradleProperty("android.minSdk").map(String::trim).get()
+            val targetSdk = providers.gradleProperty("android.targetSdk").map(String::trim).get()
+
+            version("androidCompileSdk", compileSdk)
+            version("androidMinSdk", minSdk)
+            version("androidTargetSdk", targetSdk)
+        }
+    }
 }
 
 rootProject.name = "NovaPDFReader"


### PR DESCRIPTION
## Summary
- add compile/min/target SDK versions to `gradle.properties` and expose them through the `libs` version catalog
- update the application and baseline profile modules to consume the catalog entries for SDK configuration

## Testing
- ./gradlew help

------
https://chatgpt.com/codex/tasks/task_e_68e3f00a5ea0832bbb01fe4d777eefcb