### PR TITLE
Configure Gradle build scans for CI failures

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -9,6 +9,10 @@ pluginManagement {
     }
 }
 
+plugins {
+    id("com.gradle.enterprise") version "3.16.1"
+}
+
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
@@ -29,6 +33,17 @@ dependencyResolutionManagement {
 
 rootProject.name = "NovaPDFReader"
 include(":app")
+
+if (System.getenv("CI") != null) {
+    gradleEnterprise {
+        buildScan {
+            publishOnFailure()
+            isUploadInBackground = false
+            termsOfServiceUrl = "https://gradle.com/terms-of-service"
+            termsOfServiceAgree = "yes"
+        }
+    }
+}
 
 fun isSdkDownloadEnabled(rootDir: File): Boolean {
     val gradlePropertiesFile = File(rootDir, "gradle.properties")


### PR DESCRIPTION
## Summary
- apply the Gradle Enterprise plugin to enable build scan diagnostics
- configure CI builds to publish scans on failure with synchronous upload and accepted terms

## Testing
- `./gradlew help`


------
https://chatgpt.com/codex/tasks/task_e_68e3f8950198832b9805ef8539320cac