### PR TITLE
Switch Room to KSP for reliable builds

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -58,7 +58,7 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.serialization)
-    id("org.jetbrains.kotlin.kapt")
+    alias(libs.plugins.ksp)
     alias(libs.plugins.androidx.baselineprofile)
     id("jacoco")
 }
@@ -638,7 +638,7 @@ dependencies {
 
     implementation(libs.androidx.room.runtime)
     implementation(libs.androidx.room.ktx)
-    kapt(libs.androidx.room.compiler)
+    ksp(libs.androidx.room.compiler)
 
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.kotlinx.coroutines.android)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,6 +27,7 @@ errorproneAnnotations = "2.26.1"
 junit4 = "4.13.2"
 junitJupiter = "5.10.3"
 kotlin = "1.9.24"
+ksp = "1.9.24-1.0.20"
 kotlinxCoroutines = "1.8.1"
 kotlinxSerializationJson = "1.6.3"
 lottieCompose = "6.4.0"
@@ -104,3 +105,4 @@ androidx-baselineprofile = { id = "androidx.baselineprofile", version.ref = "and
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }


### PR DESCRIPTION
## Summary
- replace the kapt plugin with the KSP plugin in the app module
- move the Room compiler dependency from kapt to ksp and wire up the catalog entry

## Testing
- `./gradlew clean`
- `TERM=dumb ./gradlew :app:assembleDebug --console=plain --stacktrace --no-build-cache`


------
https://chatgpt.com/codex/tasks/task_e_68e4600bef5c832b82725819803cbfaf