### PR TITLE
Fix unit test warning and enforce fail-fast CI

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -17,7 +17,7 @@ jobs:
     outputs:
       firebase_configured: ${{ steps.validate_required_secrets.outputs.firebase_configured }}
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         include:
           - api: 32

--- a/app/src/test/kotlin/com/novapdf/reader/data/PdfDocumentRepositoryEdgeCaseTest.kt
+++ b/app/src/test/kotlin/com/novapdf/reader/data/PdfDocumentRepositoryEdgeCaseTest.kt
@@ -61,6 +61,7 @@ class PdfDocumentRepositoryEdgeCaseTest {
             isAccessible = true
         }
         val callbacks = callbacksField.get(repository) as ComponentCallbacks2
+        @Suppress("DEPRECATION")
         callbacks.onTrimMemory(ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW)
 
         advanceUntilIdle()


### PR DESCRIPTION
## Summary
- suppress the deprecated TRIM_MEMORY_RUNNING_LOW usage in PdfDocumentRepositoryEdgeCaseTest to keep unit tests passing with -Werror
- restore fail-fast behaviour for the build-test matrix so the workflow stops when a run fails

## Testing
- ./gradlew testDebugUnitTest --info

------
https://chatgpt.com/codex/tasks/task_e_68e47cd4caf8832bb1e7bad9bdc71c5f