### PR TITLE
Add Kover coverage enforcement for core modules

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.androidx.baselineprofile) apply false
+    alias(libs.plugins.kover) apply false
 }
 
 tasks.register("clean", Delete::class) {

--- a/core-io/build.gradle.kts
+++ b/core-io/build.gradle.kts
@@ -1,3 +1,5 @@
+import kotlinx.kover.gradle.plugin.dsl.AggregationType
+import kotlinx.kover.gradle.plugin.dsl.MetricType
 import org.gradle.api.JavaVersion
 import org.gradle.api.artifacts.VersionCatalogsExtension
 
@@ -6,6 +8,7 @@ plugins {
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)
     alias(libs.plugins.kotlin.serialization)
+    alias(libs.plugins.kover)
 }
 
 val versionCatalog = extensions.getByType(VersionCatalogsExtension::class.java).named("libs")
@@ -49,4 +52,29 @@ dependencies {
 
 kotlin {
     jvmToolchain(17)
+}
+
+koverReport {
+    defaults {
+        verify {
+            rule("Core IO line coverage") {
+                bound {
+                    minValue = 75
+                    metric = MetricType.LINE
+                    aggregation = AggregationType.COVERED_PERCENTAGE
+                }
+            }
+            rule("Core IO branch coverage") {
+                bound {
+                    minValue = 55
+                    metric = MetricType.BRANCH
+                    aggregation = AggregationType.COVERED_PERCENTAGE
+                }
+            }
+        }
+    }
+}
+
+tasks.named("check") {
+    dependsOn(tasks.named("koverVerify"))
 }

--- a/core-model/build.gradle.kts
+++ b/core-model/build.gradle.kts
@@ -1,3 +1,5 @@
+import kotlinx.kover.gradle.plugin.dsl.AggregationType
+import kotlinx.kover.gradle.plugin.dsl.MetricType
 import org.gradle.api.JavaVersion
 import org.gradle.api.artifacts.VersionCatalogsExtension
 
@@ -5,6 +7,7 @@ plugins {
     id("com.android.library")
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.serialization)
+    alias(libs.plugins.kover)
 }
 
 val versionCatalog = extensions.getByType(VersionCatalogsExtension::class.java).named("libs")
@@ -34,4 +37,29 @@ dependencies {
 
 kotlin {
     jvmToolchain(17)
+}
+
+koverReport {
+    defaults {
+        verify {
+            rule("Core model line coverage") {
+                bound {
+                    minValue = 80
+                    metric = MetricType.LINE
+                    aggregation = AggregationType.COVERED_PERCENTAGE
+                }
+            }
+            rule("Core model branch coverage") {
+                bound {
+                    minValue = 60
+                    metric = MetricType.BRANCH
+                    aggregation = AggregationType.COVERED_PERCENTAGE
+                }
+            }
+        }
+    }
+}
+
+tasks.named("check") {
+    dependsOn(tasks.named("koverVerify"))
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,6 +29,7 @@ junit4 = "4.13.2"
 junitJupiter = "5.10.3"
 kotlin = "1.9.24"
 ksp = "1.9.24-1.0.20"
+kover = "0.7.5"
 kotlinxCoroutines = "1.8.1"
 kotlinxSerializationJson = "1.6.3"
 lottieCompose = "6.4.0"
@@ -110,3 +111,4 @@ kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
+kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }

--- a/pdf-engine/build.gradle.kts
+++ b/pdf-engine/build.gradle.kts
@@ -1,9 +1,12 @@
+import kotlinx.kover.gradle.plugin.dsl.AggregationType
+import kotlinx.kover.gradle.plugin.dsl.MetricType
 import org.gradle.api.JavaVersion
 import org.gradle.api.artifacts.VersionCatalogsExtension
 
 plugins {
     id("com.android.library")
     alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.kover)
 }
 
 val versionCatalog = extensions.getByType(VersionCatalogsExtension::class.java).named("libs")
@@ -46,4 +49,29 @@ dependencies {
 
 kotlin {
     jvmToolchain(17)
+}
+
+koverReport {
+    defaults {
+        verify {
+            rule("PDF engine line coverage") {
+                bound {
+                    minValue = 70
+                    metric = MetricType.LINE
+                    aggregation = AggregationType.COVERED_PERCENTAGE
+                }
+            }
+            rule("PDF engine branch coverage") {
+                bound {
+                    minValue = 50
+                    metric = MetricType.BRANCH
+                    aggregation = AggregationType.COVERED_PERCENTAGE
+                }
+            }
+        }
+    }
+}
+
+tasks.named("check") {
+    dependsOn(tasks.named("koverVerify"))
 }


### PR DESCRIPTION
## Summary
- add the Kover Gradle plugin to the build so coverage tooling is available across modules
- enable coverage verification for the core-model, core-io, and pdf-engine modules with line and branch thresholds
- wire module check tasks to depend on the new coverage verification to enforce the minimums automatically

## Testing
- ./gradlew :core-model:koverVerify --dry-run

------
https://chatgpt.com/codex/tasks/task_e_68e480c34560832ba68e3cc6b3a55cfe