### PR TITLE
Add static analysis configuration and CI checks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,23 @@
+root = true
+
+[*.{kt,kts}]
+indent_style = space
+indent_size = 4
+max_line_length = off
+ktlint_code_style = intellij_idea
+ktlint_standard_imports-ordering = disabled
+ktlint_standard_trailing-comma-on-call-site = disabled
+ktlint_standard_argument-list-wrapping = disabled
+ktlint_standard_parameter-list-wrapping = disabled
+ktlint_standard_multiline-expression-wrapping = disabled
+ktlint_standard_newline-after-parentheses = disabled
+ktlint_standard_newline-after-arrow = disabled
+ktlint_standard_redundant-curly-braces = disabled
+ktlint_standard_filename = disabled
+ktlint_standard_max-line-length = disabled
+ktlint_standard_no-unused-imports = disabled
+ktlint_standard_no-wildcard-imports = disabled
+ktlint_standard_spacing-around-paren = disabled
+ktlint_standard_annotation = disabled
+ktlint_standard_if-else-bracing = disabled
+ktlint_standard_enum-entry-name-case = disabled

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -237,6 +237,8 @@ jobs:
             gradle-
       - name: Grant execute permission for Gradle
         run: chmod +x gradlew
+      - name: Run static analysis and style checks
+        run: ./gradlew detekt spotlessCheck
       - name: Decode signing keystore
         env:
           ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}

--- a/app/src/main/kotlin/com/novapdf/reader/NovaPdfApp.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/NovaPdfApp.kt
@@ -9,13 +9,13 @@ import com.novapdf.reader.data.BookmarkManager
 import com.novapdf.reader.data.NovaPdfDatabase
 import com.novapdf.reader.data.PdfDocumentRepository
 import com.novapdf.reader.data.remote.PdfDownloadManager
+import com.novapdf.reader.engine.AdaptiveFlowManager
 import com.novapdf.reader.logging.CrashReporter
 import com.novapdf.reader.logging.FileCrashReporter
+import com.novapdf.reader.pdf.engine.DefaultAdaptiveFlowManager
 import com.novapdf.reader.search.DocumentSearchCoordinator
 import com.novapdf.reader.search.LuceneSearchCoordinator
 import com.novapdf.reader.search.PdfBoxInitializer
-import com.novapdf.reader.engine.AdaptiveFlowManager
-import com.novapdf.reader.pdf.engine.DefaultAdaptiveFlowManager
 import com.novapdf.reader.work.DocumentMaintenanceDependencies
 import com.novapdf.reader.work.DocumentMaintenanceScheduler
 import kotlinx.coroutines.CoroutineExceptionHandler

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,98 @@
+import com.diffplug.gradle.spotless.SpotlessExtension
+import io.gitlab.arturbosch.detekt.Detekt
+import io.gitlab.arturbosch.detekt.extensions.DetektExtension
+import org.gradle.api.artifacts.VersionCatalogsExtension
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.getByType
+import org.gradle.kotlin.dsl.withType
+import org.jlleitschuh.gradle.ktlint.KtlintExtension
+import org.jlleitschuh.gradle.ktlint.tasks.KtLintCheckTask
+import org.jlleitschuh.gradle.ktlint.tasks.KtLintFormatTask
+
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.androidx.baselineprofile) apply false
     alias(libs.plugins.kover) apply false
+    alias(libs.plugins.detekt) apply false
+    alias(libs.plugins.ktlint) apply false
+    alias(libs.plugins.spotless) apply false
+}
+
+val versionCatalog = extensions.getByType<VersionCatalogsExtension>().named("libs")
+val ktlintVersion = versionCatalog.findVersion("ktlint").get().requiredVersion
+
+subprojects {
+    pluginManager.apply("org.jlleitschuh.gradle.ktlint")
+    pluginManager.apply("com.diffplug.spotless")
+    pluginManager.apply("io.gitlab.arturbosch.detekt")
+
+    extensions.configure<KtlintExtension> {
+        version.set(ktlintVersion)
+        android.set(true)
+        ignoreFailures.set(false)
+        filter {
+            include("**/src/main/**/*.kt")
+            exclude("**/generated/**")
+            exclude("**/build/**")
+            exclude("**/*.kts")
+        }
+    }
+
+    extensions.configure<SpotlessExtension> {
+        kotlin {
+            if (this@subprojects.name == "app") {
+                target("src/**/*.kt")
+                targetExclude("**/build/**/*.kt", "**/src/test/**/*.kt", "**/src/androidTest/**/*.kt")
+                ktlint(ktlintVersion)
+            } else {
+                targetExclude("**/*.kt")
+            }
+        }
+    }
+
+    extensions.configure<DetektExtension> {
+        buildUponDefaultConfig = true
+        allRules = false
+        config.setFrom(files("${rootProject.projectDir}/config/detekt/detekt.yml"))
+        basePath = projectDir.absolutePath
+    }
+
+    tasks.withType<Detekt>().configureEach {
+        jvmTarget = "17"
+        exclude("**/build/**")
+        reports {
+            xml.required.set(false)
+            html.required.set(false)
+            txt.required.set(false)
+            sarif.required.set(false)
+        }
+    }
+
+    tasks.withType<KtLintCheckTask>().configureEach {
+        onlyIf { !name.contains("AndroidTest") && !name.contains("KotlinScript") }
+    }
+
+    tasks.withType<KtLintFormatTask>().configureEach {
+        onlyIf { !name.contains("AndroidTest") && !name.contains("KotlinScript") }
+    }
+
+    tasks.matching { task ->
+        task.name.startsWith("ktlint") && (task.name.contains("AndroidTest") || task.name.contains("TestSourceSet") || task.name.contains("KotlinScript"))
+    }.configureEach {
+        enabled = false
+    }
+
+    if (name == "baselineprofile") {
+        tasks.matching { it.name.startsWith("ktlint") }.configureEach {
+            enabled = false
+        }
+    }
+
+    tasks.matching { it.name == "check" }.configureEach {
+        dependsOn("spotlessCheck", "detekt")
+    }
 }
 
 tasks.register("clean", Delete::class) {

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -1,0 +1,68 @@
+build:
+  maxIssues: 0
+
+config:
+  validation: true
+  warningsAsErrors: true
+
+complexity:
+  active: true
+  LongMethod:
+    active: false
+  LongParameterList:
+    active: false
+  NestedBlockDepth:
+    active: false
+  TooManyFunctions:
+    active: false
+  LargeClass:
+    active: false
+  CyclomaticComplexMethod:
+    active: false
+  CognitiveComplexMethod:
+    active: false
+  ComplexCondition:
+    active: false
+
+style:
+  active: true
+  MagicNumber:
+    active: false
+  MaxLineLength:
+    active: false
+  WildcardImport:
+    active: false
+  ReturnCount:
+    active: false
+  ThrowsCount:
+    active: false
+  UseCheckOrError:
+    active: false
+  UnusedPrivateMember:
+    active: false
+  LoopWithTooManyJumpStatements:
+    active: false
+  UnusedParameter:
+    active: false
+  NewLineAtEndOfFile:
+    active: false
+
+exceptions:
+  active: true
+  TooGenericExceptionCaught:
+    active: false
+  SwallowedException:
+    active: false
+  InstanceOfCheckForException:
+    active: false
+
+naming:
+  active: true
+  FunctionNaming:
+    active: false
+  TopLevelPropertyNaming:
+    active: false
+  InvalidPackageDeclaration:
+    active: false
+  MatchingDeclarationName:
+    active: false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,6 +30,8 @@ junitJupiter = "5.10.3"
 kotlin = "1.9.24"
 ksp = "1.9.24-1.0.20"
 kover = "0.7.5"
+ktlint = "1.2.1"
+ktlintGradle = "12.1.1"
 kotlinxCoroutines = "1.8.1"
 kotlinxSerializationJson = "1.6.3"
 lottieCompose = "6.4.0"
@@ -43,6 +45,8 @@ pdfboxAndroid = "2.0.27.0"
 pdfium = "1.9.2"
 robolectric = "4.12.1"
 room = "2.6.1"
+detekt = "1.23.6"
+spotless = "6.25.0"
 
 [libraries]
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidxActivityCompose" }
@@ -112,3 +116,6 @@ kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
+detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
+ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlintGradle" }
+spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }


### PR DESCRIPTION
## Summary
- add detekt, ktlint, and spotless plugin versions to the version catalog
- configure the root build to apply detekt, ktlint, and spotless (with project-specific exclusions) and add a detekt configuration file
- introduce project-wide editorconfig defaults and update CI to run detekt and spotless checks

## Testing
- ./gradlew detekt spotlessCheck --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68e482496c00832ba032db6d3be56b7c