### PR TITLE
Expose ReaderActivity test hooks to instrumentation tests

### DIFF
--- a/ui-viewer/src/main/kotlin/com/novapdf/reader/ReaderActivity.kt
+++ b/ui-viewer/src/main/kotlin/com/novapdf/reader/ReaderActivity.kt
@@ -284,8 +284,8 @@ open class ReaderActivity : ComponentActivity() {
         }
     }
 
-    @VisibleForTesting
-    internal fun openDocumentForTest(uri: Uri) {
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    fun openDocumentForTest(uri: Uri) {
         if (!useComposeUi) {
             viewModel.openDocument(uri)
             return
@@ -298,8 +298,8 @@ open class ReaderActivity : ComponentActivity() {
         }
     }
 
-    @VisibleForTesting
-    internal fun currentDocumentStateForTest(): PdfViewerUiState {
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    fun currentDocumentStateForTest(): PdfViewerUiState {
         return viewModel.uiState.value
     }
 


### PR DESCRIPTION
## Summary
- allow androidTest sources to invoke ReaderActivity test helpers by making them public
- retain VisibleForTesting annotations while keeping helper implementations unchanged

## Testing
- ./gradlew app:compileDebugAndroidTestKotlin --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68e48c58aa14832bb853e4162a440cba