### PR TITLE
Fix androidTest warnings

### DIFF
--- a/app/src/androidTest/kotlin/com/novapdf/reader/StorageDirectoryCandidates.kt
+++ b/app/src/androidTest/kotlin/com/novapdf/reader/StorageDirectoryCandidates.kt
@@ -15,7 +15,9 @@ internal fun writableStorageCandidates(context: Context): List<File> {
         context.externalCacheDirs?.forEach { dir -> dir?.let(::add) }
         context.getExternalFilesDir(null)?.let(::add)
         context.getExternalFilesDirs(null)?.forEach { dir -> dir?.let(::add) }
-        context.externalMediaDirs?.forEach { dir -> dir?.let(::add) }
+        @Suppress("DEPRECATION")
+        val externalMediaDirectories = context.externalMediaDirs
+        externalMediaDirectories?.forEach { dir -> dir?.let(::add) }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             context.dataDir?.let(::add)
         }

--- a/app/src/androidTest/kotlin/com/novapdf/reader/TestDocumentFixtures.kt
+++ b/app/src/androidTest/kotlin/com/novapdf/reader/TestDocumentFixtures.kt
@@ -491,7 +491,7 @@ internal object TestDocumentFixtures {
     private fun validatePageTree(candidate: File, contents: String): Boolean {
         val kidsMatcher = KIDS_ARRAY_PATTERN.matcher(contents)
         while (kidsMatcher.find()) {
-            val kidsSection = kidsMatcher.group(1)
+            val kidsSection = kidsMatcher.group(1) ?: continue
             val referenceMatcher = REFERENCE_PATTERN.matcher(kidsSection)
             var referenceCount = 0
             while (referenceMatcher.find()) {


### PR DESCRIPTION
## Summary
- suppress the deprecated `externalMediaDirs` accessor in androidTest storage directory enumeration
- guard against null page tree matcher groups when validating generated PDFs

## Testing
- ./gradlew --console=plain :app:compileDebugAndroidTestKotlin *(fails: resource merge error in :app:mergeDebugResources)*

------
https://chatgpt.com/codex/tasks/task_e_68e49585ca5c832b8128b23a86ee96c0