### PR TITLE
Enable StrictMode policies in debug builds

### DIFF
--- a/app/src/main/kotlin/com/novapdf/reader/NovaPdfApp.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/NovaPdfApp.kt
@@ -2,6 +2,7 @@ package com.novapdf.reader
 
 import android.app.Application
 import android.content.Context
+import android.os.StrictMode
 import android.util.Log
 import androidx.room.Room
 import com.novapdf.reader.data.AnnotationRepository
@@ -81,6 +82,23 @@ open class NovaPdfApp : Application(), DocumentMaintenanceDependencies, NovaPdfD
         super.onCreate()
         // Install crash handling immediately so background initialisation can report failures.
         crashReporter
+
+        if (BuildConfig.DEBUG) {
+            StrictMode.setThreadPolicy(
+                StrictMode.ThreadPolicy.Builder()
+                    .detectDiskReads()
+                    .detectDiskWrites()
+                    .detectNetwork()
+                    .penaltyDeath()
+                    .build()
+            )
+            StrictMode.setVmPolicy(
+                StrictMode.VmPolicy.Builder()
+                    .detectAll()
+                    .penaltyDeath()
+                    .build()
+            )
+        }
 
         // Schedule heavy singletons to initialise off the main thread.
         applicationScope.launch {


### PR DESCRIPTION
## Summary
- enable StrictMode thread and VM policies when running debug builds so that disk and network access on the main thread crash immediately

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e5443855d8832b883a54ecdfd916b8