### PR TITLE
Use App Startup for NovaPdf background initialization

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -774,6 +774,7 @@ dependencies {
     implementation(libs.androidx.work.runtime.ktx)
     implementation(libs.androidx.security.crypto)
     implementation(libs.androidx.profileinstaller)
+    implementation(libs.androidx.startup.runtime)
     implementation(libs.pdfium.android) {
         exclude(group = "com.android.support", module = "support-compat")
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,6 +25,10 @@
             android:name="androidx.profileinstaller.PROFILE_INSTALLER_ENABLED"
             android:value="false" />
 
+        <meta-data
+            android:name="com.novapdf.reader.startup.NovaPdfInitializer"
+            android:value="androidx.startup" />
+
         <activity
             android:name="com.novapdf.reader.ReaderActivity"
             android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"

--- a/app/src/main/kotlin/com/novapdf/reader/startup/NovaPdfInitializer.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/startup/NovaPdfInitializer.kt
@@ -1,0 +1,18 @@
+package com.novapdf.reader.startup
+
+import android.content.Context
+import androidx.startup.Initializer
+import com.novapdf.reader.NovaPdfApp
+
+class NovaPdfInitializer : Initializer<Unit> {
+    override fun create(context: Context) {
+        val application = context.applicationContext as? NovaPdfApp
+            ?: throw IllegalStateException(
+                "NovaPdfInitializer requires NovaPdfApp as the application context"
+            )
+
+        application.beginStartupInitialization()
+    }
+
+    override fun dependencies(): List<Class<out Initializer<*>>> = emptyList()
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,6 +22,7 @@ androidxTestExtJunit = "1.2.1"
 androidxTestOrchestrator = "1.4.2"
 androidxTestUiautomator = "2.3.0"
 androidxWork = "2.9.0"
+androidxStartup = "1.1.1"
 caffeine = "2.9.3"
 coil = "3.0.0"
 errorproneAnnotations = "2.26.1"
@@ -92,6 +93,7 @@ androidx-room-common = { module = "androidx.room:room-common", version.ref = "ro
 androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "room" }
 androidx-room-testing = { module = "androidx.room:room-testing", version.ref = "room" }
 androidx-security-crypto = { module = "androidx.security:security-crypto", version.ref = "androidxSecurityCrypto" }
+androidx-startup-runtime = { module = "androidx.startup:startup-runtime", version.ref = "androidxStartup" }
 androidx-test-core = { module = "androidx.test:core", version.ref = "androidxTestCore" }
 androidx-test-espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "androidxTestEspresso" }
 androidx-test-ext-junit = { module = "androidx.test.ext:junit", version.ref = "androidxTestExtJunit" }


### PR DESCRIPTION
## Summary
- move deferred NovaPdf initialization scheduling into an App Startup initializer and guard against duplicate execution
- keep `Application.onCreate` limited to lightweight setup while preserving deferred component initialization
- add the AndroidX Startup dependency and register the initializer in the manifest

## Testing
- ./gradlew :app:assembleDebug

------
https://chatgpt.com/codex/tasks/task_e_68e544f017dc832bb9f19bdc9f4ba104