### PR TITLE
Fix baseline profile compile warning

### DIFF
--- a/baselineprofile/src/main/java/com/novapdf/reader/baselineprofile/BenchmarkScenarios.kt
+++ b/baselineprofile/src/main/java/com/novapdf/reader/baselineprofile/BenchmarkScenarios.kt
@@ -79,7 +79,7 @@ private fun waitForReaderActivity(instrumentation: Instrumentation): Activity {
     repeat(20) {
         val resumed = ActivityLifecycleMonitorRegistry.getInstance()
             .getActivitiesInStage(Stage.RESUMED)
-            .firstOrNull { readerActivityClass.isInstance(it) } as? Activity
+            .firstOrNull { readerActivityClass.isInstance(it) }
         if (resumed != null) {
             return resumed
         }


### PR DESCRIPTION
## Summary
- remove the redundant cast when locating the resumed ReaderActivity so the baselineprofile module no longer emits a warning under -Werror

## Testing
- ./gradlew :baselineprofile:compileBenchmarkBenchmarkKotlin

------
https://chatgpt.com/codex/tasks/task_e_68e548cc8ddc832bbd7d74bcbcc79c1e