### PR TITLE
Fix spotless violation in NovaPdfApp

### DIFF
--- a/app/src/main/kotlin/com/novapdf/reader/NovaPdfApp.kt
+++ b/app/src/main/kotlin/com/novapdf/reader/NovaPdfApp.kt
@@ -101,7 +101,6 @@ open class NovaPdfApp : Application(), DocumentMaintenanceDependencies, NovaPdfD
                     .build()
             )
         }
-
     }
 
     override fun onTerminate() {


### PR DESCRIPTION
## Summary
- remove the stray blank line in NovaPdfApp.onCreate to satisfy Spotless formatting rules

## Testing
- ./gradlew detekt spotlessCheck --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68e54c86e178832b8c222b45e4867417