### PR TITLE
Restrict ReaderActivity export status

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -32,7 +32,7 @@
         <activity
             android:name="com.novapdf.reader.ReaderActivity"
             android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"
-            android:exported="true"
+            android:exported="false"
             android:launchMode="singleTask" />
 
         <activity


### PR DESCRIPTION
## Summary
- mark ReaderActivity as non-exported so only the launcher activity remains externally available

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e55708b824832b9dd481690ba3bb8f