### PR TITLE
Adjust backup configuration per build type

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,7 +15,8 @@
     <application
         android:name="com.novapdf.reader.NovaPdfApp"
         android:allowBackup="true"
-        android:fullBackupContent="true"
+        android:fullBackupContent="@xml/backup_rules"
+        android:dataExtractionRules="@xml/data_extraction_rules"
         android:icon="@drawable/ic_pdf"
         android:label="@string/app_name"
         android:roundIcon="@drawable/ic_pdf"

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<full-backup-content>
+    <!-- Exclude caches and remote PDFs that can be re-downloaded. -->
+    <exclude domain="root" path="cache/" />
+    <exclude domain="file" path="remote_pdfs/" />
+</full-backup-content>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<data-extraction-rules xmlns:android="http://schemas.android.com/apk/res/android">
+    <cloud-backup>
+        <include domain="sharedpref" path="." />
+        <include domain="database" path="." />
+        <exclude domain="root" path="cache/" />
+        <exclude domain="file" path="remote_pdfs/" />
+    </cloud-backup>
+    <device-transfer>
+        <include domain="sharedpref" path="." />
+        <include domain="database" path="." />
+        <exclude domain="root" path="cache/" />
+        <exclude domain="file" path="remote_pdfs/" />
+    </device-transfer>
+</data-extraction-rules>

--- a/app/src/release/AndroidManifest.xml
+++ b/app/src/release/AndroidManifest.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <application
+        android:allowBackup="false"
+        tools:replace="android:allowBackup" />
+</manifest>


### PR DESCRIPTION
## Summary
- disable app data backups in release builds via a manifest overlay
- configure main manifest to use filtered backup and data extraction rules when backups are enabled
- add XML rules that exclude cached remote PDFs from cloud/device transfer backups

## Testing
- `./gradlew :app:processDebugMainManifest --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_68e557fdefbc832bb76e646e6316b702