### PR TITLE
Enable no-streaming ADB installs on CI

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -318,11 +318,13 @@ android {
             (findProperty("novapdf.enableNoStreamingInstallOption") as? String)
                 ?: System.getenv("NOVAPDF_ENABLE_NO_STREAMING")
         )
-        val enableNoStreaming = explicitNoStreaming ?: false
+        val enableNoStreaming = explicitNoStreaming ?: isCiEnvironment
 
         if (enableNoStreaming) {
             // Allow opting into legacy installs because some hosted emulators
-            // intermittently fail session commits unless the legacy path is used.
+            // intermittently fail session commits unless the legacy path is used. Default to the
+            // legacy flow on CI because the package manager can report
+            // `IllegalStateException` when streaming installs race the boot process.
             installOptions.add("--no-streaming")
         }
     }


### PR DESCRIPTION
## Summary
- default Gradle ADB installs to the legacy --no-streaming path when running in CI
- document why the CI path is needed to avoid PackageInstaller IllegalStateException during boot

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e55c1c398c832b86281249923a9e8e