### PR TITLE
Make dependency analysis plugin optional

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,11 +18,24 @@ plugins {
     alias(libs.plugins.detekt) apply false
     alias(libs.plugins.ktlint) apply false
     alias(libs.plugins.spotless) apply false
-    alias(libs.plugins.dependency.analysis)
+    alias(libs.plugins.dependency.analysis) apply false
 }
 
 val versionCatalog = extensions.getByType<VersionCatalogsExtension>().named("libs")
 val ktlintVersion = versionCatalog.findVersion("ktlint").get().requiredVersion
+
+val dependencyAnalysisRequested = gradle.startParameter.taskNames.any { taskName ->
+    taskName.contains("dependency", ignoreCase = true) ||
+        taskName.contains("buildHealth", ignoreCase = true)
+}
+
+val dependencyAnalysisEnabled = providers.gradleProperty("novapdf.enableDependencyAnalysis")
+    .map { it.equals("true", ignoreCase = true) }
+    .orElse(false)
+
+if (dependencyAnalysisRequested || dependencyAnalysisEnabled.get()) {
+    pluginManager.apply("com.autonomousapps.dependency-analysis")
+}
 
 subprojects {
     pluginManager.apply("org.jlleitschuh.gradle.ktlint")


### PR DESCRIPTION
## Summary
- stop applying the dependency analysis plugin by default to avoid variant clashes with AGP 8.5
- allow re-enabling the plugin on demand via a Gradle property or when dependency analysis tasks are invoked

## Testing
- ./gradlew :app:mergeReleaseBaselineProfile -m --console=plain --no-configuration-cache

------
https://chatgpt.com/codex/tasks/task_e_68e5f3bc339c832ba37d7911beec9e3b