### PR TITLE
Fix baseline profile verification in CI workflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -955,7 +955,9 @@ jobs:
         if: matrix.device_label == 'pixel-7-pro'
         run: |
           set -euo pipefail
-          generated=$(find app/build -path '*/baselineProfile/*/baseline-prof.txt' -type f -print -quit)
+          generated=$(find app/build \
+            \( -path '*/baselineProfile/*/baseline-prof.txt' -o -path '*/baselineprofiles/*/baseline-prof.txt' \) \
+            -type f -print -quit)
           if [ -z "$generated" ]; then
             echo "::error::Failed to locate generated baseline profile under app/build" >&2
             find app/build -maxdepth 4 -type d -print >&2 || true


### PR DESCRIPTION
## Summary
- update the CI baseline profile verification step to recognize both legacy and new output directories used by the Android Baseline Profile plugin

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68e6002749fc832b880eadf94489aa47