### PR TITLE
Fix baseline profile verification path in CI

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -955,9 +955,7 @@ jobs:
         if: matrix.device_label == 'pixel-7-pro'
         run: |
           set -euo pipefail
-          generated=$(find app/build \
-            \( -path '*/baselineProfile/*/baseline-prof.txt' -o -path '*/baselineprofiles/*/baseline-prof.txt' \) \
-            -type f -print -quit)
+          generated=$(find app/build -type f -iname 'baseline-prof.txt' -path '*/release/*' -print -quit)
           if [ -z "$generated" ]; then
             echo "::error::Failed to locate generated baseline profile under app/build" >&2
             find app/build -maxdepth 4 -type d -print >&2 || true

--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ the `baselineprofile` module.
 
    ```bash
    ./gradlew :app:generateReleaseBaselineProfile --stacktrace
-   cp app/build/outputs/baselineProfile/release/baseline-prof.txt app/src/main/baseline-prof.txt
+   cp "$(find app/build -type f -iname 'baseline-prof.txt' -path '*/release/*' -print -quit)" \
+     app/src/main/baseline-prof.txt
    ```
 
 5. Review the diff and commit the updated file together with any performance-sensitive


### PR DESCRIPTION
## Summary
- broaden the CI workflow's search for the generated release baseline profile to handle variant directory changes
- update the README to use the same discovery logic when copying the refreshed baseline profile

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e609b8a3d0832bb3a251f797ca15ad