### PR TITLE
Ensure release baseline profile is copied to a stable output

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -984,4 +984,33 @@ kotlin {
             shouldRunAfter("adaptiveFlowPerformance")
         }
     }
+
+    val releaseBaselineProfileSource = project.layout.buildDirectory
+        .file("intermediates/merged_art_profile/benchmarkRelease/mergeBenchmarkReleaseArtProfile/baseline-prof.txt")
+    val releaseBaselineProfileOutput = project.layout.buildDirectory
+        .file("outputs/baselineprofile/release/baseline-prof.txt")
+
+    val syncReleaseBaselineProfile = tasks.register("syncReleaseBaselineProfile") {
+        group = "build"
+        description = "Copies the generated release baseline profile to a stable output directory."
+
+        inputs.file(releaseBaselineProfileSource)
+        outputs.file(releaseBaselineProfileOutput)
+
+        doLast {
+            val sourceFile = releaseBaselineProfileSource.get().asFile
+            if (!sourceFile.exists()) {
+                logger.warn("Release baseline profile was not generated at ${'$'}{sourceFile.absolutePath}")
+                return@doLast
+            }
+
+            val outputFile = releaseBaselineProfileOutput.get().asFile
+            outputFile.parentFile.mkdirs()
+            sourceFile.copyTo(outputFile, overwrite = true)
+        }
+    }
+
+    tasks.namedOrNull<Task>("generateReleaseBaselineProfile")?.configure {
+        finalizedBy(syncReleaseBaselineProfile)
+    }
 }


### PR DESCRIPTION
## Summary
- add a sync task that copies the generated release baseline profile into app/build/outputs/baselineprofile/release
- finalize generateReleaseBaselineProfile to publish the file where CI expects it

## Testing
- ./gradlew help --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68e62c174314832b84ba0daaa95157ad