### PR TITLE
Handle missing release baseline profile source

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -994,7 +994,10 @@ kotlin {
         group = "build"
         description = "Copies the generated release baseline profile to a stable output directory."
 
-        inputs.file(releaseBaselineProfileSource)
+        inputs
+            .files(releaseBaselineProfileSource)
+            .withPropertyName("releaseBaselineProfileSource")
+            .optional()
         outputs.file(releaseBaselineProfileOutput)
 
         doLast {


### PR DESCRIPTION
## Summary
- make the syncReleaseBaselineProfile task tolerate absent baseline profile inputs during CI runs

## Testing
- `./gradlew app:generateReleaseBaselineProfile --console=plain` *(fails: SigningConfig "release" is missing required property "storeFile" in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e633afd150832b991613c86a0a5f2e