### PR TITLE
Enable connected CI tests by default

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -394,7 +394,11 @@ val allowCiConnectedTests = parseOptionalBoolean(
     (findProperty("novapdf.allowCiConnectedTests") as? String)
         ?: providers.gradleProperty("novapdf.allowCiConnectedTests").orNull
         ?: System.getenv("NOVAPDF_ALLOW_CI_CONNECTED_TESTS")
-)
+) ?: if (isCiEnvironment) {
+    true
+} else {
+    null
+}
 
 fun locateAndroidSdkDir(): File? {
     val localProperties = rootProject.file("local.properties")

--- a/baselineprofile/build.gradle.kts
+++ b/baselineprofile/build.gradle.kts
@@ -188,7 +188,11 @@ val allowCiConnectedTests = parseOptionalBoolean(
     (findProperty("novapdf.allowCiConnectedTests") as? String)
         ?: providers.gradleProperty("novapdf.allowCiConnectedTests").orNull
         ?: System.getenv("NOVAPDF_ALLOW_CI_CONNECTED_TESTS")
-)
+) ?: if (isCiBuild) {
+    true
+} else {
+    null
+}
 
 val skipConnectedTestsOnCi = isCiBuild && allowCiConnectedTests != true && requireConnectedDevice != true
 


### PR DESCRIPTION
## Summary
- default CI runs to allow connected Android tests when novapdf.allowCiConnectedTests is not set in the app module
- mirror the same default in the baselineprofile module so macrobenchmarks run on CI

## Testing
- ./gradlew -q --version

------
https://chatgpt.com/codex/tasks/task_e_68e67dd43cb8832bb9fd637eb323da52