### PR TITLE
Avoid adb device check during configuration

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -554,8 +554,12 @@ if (requireConnectedDevice != true) {
 
                     androidComponents.beforeVariants { variantBuilder ->
                         val buildTypeName = variantBuilder.buildType ?: ""
-                        if (buildTypeName.contains("benchmark", ignoreCase = true) && !hasConnectedDevice) {
+                        if (
+                            buildTypeName.contains("benchmark", ignoreCase = true) &&
+                                !gradle.startParameter.requestsConnectedAndroidTests()
+                        ) {
                             variantBuilder.enableUnitTest = false
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- avoid invoking `adb devices` during configuration by basing benchmark unit test gating on requested tasks

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e687d5fafc832bbdb33cc984ee3f61