### PR TITLE
Add network security config for local test hosts

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,10 +17,12 @@
         android:allowBackup="true"
         android:fullBackupContent="@xml/backup_rules"
         android:dataExtractionRules="@xml/data_extraction_rules"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:icon="@drawable/ic_pdf"
         android:label="@string/app_name"
         android:roundIcon="@drawable/ic_pdf"
         android:supportsRtl="true"
+        android:usesCleartextTraffic="false"
         android:theme="@style/Theme.NovaPDFReader">
         <meta-data
             android:name="androidx.profileinstaller.PROFILE_INSTALLER_ENABLED"

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Restrict cleartext traffic by default so production builds require HTTPS.
+     Local instrumentation and CI harnesses rely on HTTP endpoints for fixture
+     downloads and coordination, so explicitly opt the known hostnames back in.
+-->
+<network-security-config>
+    <base-config cleartextTrafficPermitted="false">
+        <trust-anchors>
+            <certificates src="system" />
+            <certificates src="user" />
+        </trust-anchors>
+    </base-config>
+
+    <domain-config cleartextTrafficPermitted="true">
+        <!-- Android emulator loopback to the host machine. -->
+        <domain>10.0.2.2</domain>
+        <!-- Genymotion and some CI runners expose the host at 10.0.3.2. -->
+        <domain>10.0.3.2</domain>
+        <!-- Localhost aliases for Robolectric or forwarded ports. -->
+        <domain>127.0.0.1</domain>
+        <domain>localhost</domain>
+        <!-- Docker-based CI sometimes exposes services under this hostname. -->
+        <domain>host.docker.internal</domain>
+    </domain-config>
+</network-security-config>


### PR DESCRIPTION
## Summary
- add a network security config that disables cleartext traffic by default
- explicitly allow HTTP access to localhost-style hosts used by local and CI test harnesses
- wire the application manifest up to the new config and disable cleartext traffic globally

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e68f051e70832bbc3f5753066e7e06