### PR TITLE
Remove legacy storage permissions

### DIFF
--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools">
-
-    <!-- Remove storage manager permission from debug builds to avoid installation failures on test devices. -->
-    <uses-permission
-        android:name="android.permission.MANAGE_EXTERNAL_STORAGE"
-        tools:node="remove" />
-</manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,16 +2,6 @@
 <manifest
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-    <!-- MANAGE_EXTERNAL_STORAGE is declared so API 30-33 users can opt in from the explicit
-         settings screen launched by ReaderActivity. Keeping the permission behind that settings
-         flow lets us honour scoped storage/Play policy requirements while still enabling the
-         in-app PDF library browser. -->
-    <uses-permission
-        android:name="android.permission.MANAGE_EXTERNAL_STORAGE"
-        android:maxSdkVersion="33"
-        tools:targetApi="r" />
-
     <application
         android:name="com.novapdf.reader.NovaPdfApp"
         android:allowBackup="true"

--- a/app/src/main/baseline-prof.txt
+++ b/app/src/main/baseline-prof.txt
@@ -4,12 +4,8 @@ Lcom/novapdf/reader/ReaderActivity;
 HSPLcom/novapdf/reader/ReaderActivity;->onCreate(Landroid/os/Bundle;)V
 HSPLcom/novapdf/reader/ReaderActivity;->onResume()V
 HSPLcom/novapdf/reader/ReaderActivity;->onPause()V
-HSPLcom/novapdf/reader/ReaderActivity;->requestStoragePermissionIfNeeded()V
 HSPLcom/novapdf/reader/ReaderActivity;->openRemoteDocument(Ljava/lang/String;)V
-HSPLcom/novapdf/reader/ReaderActivity;->handleReadStoragePermissionResult(Z)V
-HSPLcom/novapdf/reader/ReaderActivity;->handleManageAllFilesResult()V
 Lcom/novapdf/reader/MainActivity;
-HSPLcom/novapdf/reader/MainActivity;->onCreate(Landroid/os/Bundle;)V
 Lcom/novapdf/reader/PdfViewerViewModel;
 HSPLcom/novapdf/reader/PdfViewerViewModel;->openDocument(Landroid/net/Uri;)V
 HSPLcom/novapdf/reader/PdfViewerViewModel;->openRemoteDocument(Ljava/lang/String;)V

--- a/ui-viewer/src/main/kotlin/com/novapdf/reader/MainActivity.kt
+++ b/ui-viewer/src/main/kotlin/com/novapdf/reader/MainActivity.kt
@@ -1,34 +1,6 @@
 package com.novapdf.reader
 
-import android.Manifest
-import android.content.pm.PackageManager
-import android.os.Build
-import android.os.Bundle
-import android.os.Environment
-import androidx.core.content.ContextCompat
-
 /**
- * Entry point activity used by automated UI tooling. Adds runtime permission detection so
- * storage access prompts are issued automatically when needed.
+ * Entry point activity that delegates to [ReaderActivity].
  */
-class MainActivity : ReaderActivity() {
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        verifyStorageAccess()
-    }
-
-    private fun verifyStorageAccess() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) return
-        val hasAccess = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            Environment.isExternalStorageManager()
-        } else {
-            ContextCompat.checkSelfPermission(
-                this,
-                Manifest.permission.READ_EXTERNAL_STORAGE
-            ) == PackageManager.PERMISSION_GRANTED
-        }
-        if (!hasAccess) {
-            requestStoragePermissionIfNeeded()
-        }
-    }
-}
+class MainActivity : ReaderActivity()

--- a/ui-viewer/src/main/res/values/strings.xml
+++ b/ui-viewer/src/main/res/values/strings.xml
@@ -7,11 +7,6 @@
     <string name="adaptive_flow_off">Adaptive Flow Paused</string>
     <string name="annotation_saved">Annotations saved</string>
     <string name="annotation_discarded">Annotations discarded</string>
-    <string name="storage_permission_manage_explanation">NovaPDF Reader needs "All files access" to browse and open PDFs stored on your device. Tap Open settings to allow access.</string>
-    <string name="storage_permission_read_explanation">NovaPDF Reader needs storage permission to open PDFs stored on your device.</string>
-    <string name="storage_permission_granted">Storage access granted. You can now browse your PDFs.</string>
-    <string name="storage_permission_denied">Storage access is still disabled. You can enable it anytime from Settings.</string>
-    <string name="storage_permission_open_settings">Open settings</string>
     <string name="accessibility_settings_title">Accessibility options</string>
     <string name="accessibility_open_options">Accessibility options</string>
     <string name="accessibility_sheet_title">Tune accessibility</string>


### PR DESCRIPTION
## Summary
- drop legacy READ_EXTERNAL_STORAGE and MANAGE_EXTERNAL_STORAGE declarations now that the reader relies on the Storage Access Framework
- delete the unused debug manifest override and remove runtime storage-permission prompts from ReaderActivity/MainActivity
- clean up obsolete strings and baseline profile entries tied to the removed permission flow

## Testing
- ./gradlew :app:lint --console=plain *(fails: existing lint error about cache/ not being in an included path in data_extraction_rules.xml)*

------
https://chatgpt.com/codex/tasks/task_e_68e690ae7930832b838d311059ac6c4f